### PR TITLE
Release/2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## v2.0.0
+
+SpawnHunt now supports multiplayer — run hunts on any Fabric server with full HUD sync for mod clients and action bar fallback for vanilla players.
+
+### Added
+
+- Multiplayer support — server-authoritative hunts managed via /spawnhunt commands (start, stop, restart, status)
+- Server-to-client HUD sync — mod clients see the full SpawnHunt HUD (target item, timer) during multiplayer hunts
+- Vanilla client compatibility — players without the mod receive target and timer updates via the action bar, plus chat messages for start/stop/win events
+- Server-side win detection — inventory scanning and victory announcements are handled by the server
+
+### Improved
+
+- HUD rendering — updated to support both singleplayer and multiplayer state sources seamlessly
+- Hunt state cleanup — state resets properly on disconnect for both singleplayer and multiplayer sessions
+
 ## v1.3.0
 
 This release redesigns the main menu and HUD for a cleaner look, improves item display names, and fixes several item pool and layout issues.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,8 +142,7 @@ Uses [SemVer](https://semver.org/). Version is set in `gradle.properties` (`mod_
 
 | Version | Date       | Notes                                    |
 |---------|------------|------------------------------------------|
-| 2.0.0 | 2026-03-16 |  |
-| 1.4.0 | 2026-03-16 | Multiplayer support: server commands, HUD sync, vanilla client action bar |
+| 2.0.0 | 2026-03-16 | Multiplayer support: server commands, HUD sync, vanilla client action bar |
 | 1.3.0 | 2026-03-15 | HUD redesign, vertical menu layout, music disc naming, item pool fixes |
 | 1.2.0   | 2026-03-12 | Music disc song names, display name caching |
 | 1.1.0   | 2026-02-26 | UI polish, win state rework, world naming   |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,7 @@ Uses [SemVer](https://semver.org/). Version is set in `gradle.properties` (`mod_
 | Version | Date       | Notes                                    |
 |---------|------------|------------------------------------------|
 | 2.0.0 | 2026-03-16 |  |
+| 2.0.0 | 2026-03-16 |  |
 | 2.0.0 | 2026-03-16 | Multiplayer support: server commands, HUD sync, vanilla client action bar |
 | 1.3.0 | 2026-03-15 | HUD redesign, vertical menu layout, music disc naming, item pool fixes |
 | 1.2.0   | 2026-03-12 | Music disc song names, display name caching |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,7 @@ Uses [SemVer](https://semver.org/). Version is set in `gradle.properties` (`mod_
 
 | Version | Date       | Notes                                    |
 |---------|------------|------------------------------------------|
+| 2.0.0 | 2026-03-16 |  |
 | 2.0.0 | 2026-03-16 | Multiplayer support: server commands, HUD sync, vanilla client action bar |
 | 1.3.0 | 2026-03-15 | HUD redesign, vertical menu layout, music disc naming, item pool fixes |
 | 1.2.0   | 2026-03-12 | Music disc song names, display name caching |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,7 @@ Uses [SemVer](https://semver.org/). Version is set in `gradle.properties` (`mod_
 
 | Version | Date       | Notes                                    |
 |---------|------------|------------------------------------------|
+| 2.0.0 | 2026-03-16 |  |
 | 1.4.0 | 2026-03-16 | Multiplayer support: server commands, HUD sync, vanilla client action bar |
 | 1.3.0 | 2026-03-15 | HUD redesign, vertical menu layout, music disc naming, item pool fixes |
 | 1.2.0   | 2026-03-12 | Music disc song names, display name caching |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,8 @@
 # SpawnHunt
 
-A Fabric client-side mod for Minecraft Java Edition 1.21.11.
+A Fabric mod for Minecraft Java Edition 1.21.11.
 Speedrun-style scavenger hunt: find and collect a random survival-obtainable block as fast as possible.
+Supports both singleplayer (client-side) and multiplayer (server-side commands + HUD sync).
 
 ## Testing Environment
 
@@ -14,19 +15,29 @@ Speedrun-style scavenger hunt: find and collect a random survival-obtainable blo
 
 ```
 com.spawnhunt
-├── SpawnHuntMod.java              // Entrypoint (ClientModInitializer)
+├── SpawnHuntMod.java              // Client entrypoint (ClientModInitializer)
+├── SpawnHuntCommon.java           // Common entrypoint (ModInitializer) — packets, commands, server tick
 ├── data/
 │   ├── ItemPool.java              // Survival-obtainable item registry & random selection
-│   ├── HuntState.java            // Active hunt state (target, timer, win flag)
+│   ├── HuntState.java            // Singleplayer hunt state (target, timer, win flag)
+│   ├── ServerHuntState.java      // Server-authoritative multiplayer hunt state
 │   └── ResultStore.java          // Persisted run results (last/top times per item)
+├── command/
+│   └── SpawnHuntCommand.java      // /spawnhunt command tree (Brigadier)
+├── network/
+│   ├── SpawnHuntPayloads.java     // Payload ID constants + registration
+│   ├── HuntSyncS2CPayload.java   // Periodic state sync (server -> client)
+│   ├── HuntWinS2CPayload.java    // Win announcement (server -> client)
+│   └── ClientHuntState.java      // Client-side mirror of server state
 ├── screen/
 │   ├── SpawnHuntScreen.java       // Item selection GUI (Cancel / List / Reroll / Start)
 │   └── ItemChooserScreen.java     // Searchable item list picker (Back / Select)
 ├── hud/
-│   └── HuntHudRenderer.java      // In-game HUD (timer + target icon/name, green border/name on win)
+│   └── HuntHudRenderer.java      // In-game HUD (dual source: SP HuntState / MP ClientHuntState)
 ├── event/
-│   ├── InventoryListener.java     // Detects target block entering inventory
-│   └── WorldLifecycleHandler.java // Resets hunt state on world exit
+│   ├── InventoryListener.java     // Detects target block entering inventory (singleplayer)
+│   ├── WorldLifecycleHandler.java // Resets hunt state on world exit
+│   └── ServerHuntManager.java     // Server tick: inventory scan, timer broadcast, win detection
 └── mixin/
     ├── TitleScreenMixin.java      // Injects "SpawnHunt" button into main menu
     └── CreateWorldScreenMixin.java // Auto-configures and triggers world creation
@@ -101,13 +112,24 @@ JAVA_HOME="/c/Program Files/Eclipse Adoptium/jdk-21.0.10.7-hotspot" ./gradlew bu
 - [x] 9.4 Playtesting (easy + hard targets, timer accuracy)
 - [x] 9.5 Build & distribute (final .jar, clean install test)
 
+### Phase M — Multiplayer Support
+- [x] M1 Common infrastructure (SpawnHuntCommon entrypoint, payload registration, fabric.mod.json)
+- [x] M2 Server state + commands (ServerHuntState, /spawnhunt command tree)
+- [x] M3 Server tick handler (inventory scan, mod client sync, vanilla action bar, win detection)
+- [x] M4 Client integration (ClientHuntState, packet receivers, dual-source HUD)
+- [x] M5 Polish (seconds-only timer for MP, win timer fix, action bar cleanup)
+
 ## Key Design Decisions
 
 - **State is not persisted** — exiting the world ends the hunt. Crash = hunt over.
 - **Item pool** uses tag-and-filter: start with all registry items, filter survival-obtainables, exclude unobtainables via a static exclusion set.
 - **Win state** — no separate overlay; HUD border and item name turn green, victory sound plays.
-- **Timer** uses delta-accumulation (not start-time subtraction) to avoid drift across pause/unpause.
+- **Singleplayer timer** uses delta-accumulation (not start-time subtraction) to avoid drift across pause/unpause.
+- **Multiplayer timer** uses server wall-clock (no pause concept); displayed in mm:ss format (no milliseconds).
 - **Inventory scanning** is trivially fast (36 slots + armor + offhand per tick).
+- **Two separate state paths** — singleplayer uses `HuntState` (client static), multiplayer uses `ServerHuntState` (server) synced to `ClientHuntState` (client mirror). No shared mutable state.
+- **Vanilla client support** — players without the mod see action bar messages during active hunts and chat messages for start/stop/win events.
+- **Multiplayer commands** require OP level 2 (GAMEMASTERS); `/spawnhunt status` is available to all players.
 
 ## Key Risks
 
@@ -120,7 +142,7 @@ Uses [SemVer](https://semver.org/). Version is set in `gradle.properties` (`mod_
 
 | Version | Date       | Notes                                    |
 |---------|------------|------------------------------------------|
-| 1.3.0 | 2026-03-15 |  |
+| 1.4.0 | 2026-03-16 | Multiplayer support: server commands, HUD sync, vanilla client action bar |
 | 1.3.0 | 2026-03-15 | HUD redesign, vertical menu layout, music disc naming, item pool fixes |
 | 1.2.0   | 2026-03-12 | Music disc song names, display name caching |
 | 1.1.0   | 2026-02-26 | UI polish, win state rework, world naming   |

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # SpawnHunt
 
-**SpawnHunt** is a client-side Fabric mod that turns Minecraft into a speedrun scavenger hunt. You're given a random survival-obtainable item — collect it in a fresh world as fast as you can.
+**SpawnHunt** is a Fabric mod that turns Minecraft into a speedrun scavenger hunt. You're given a random survival-obtainable item — collect it as fast as you can. Play solo in a fresh world or compete with friends on a server.
 
 ## How It Works
+
+### Singleplayer
 
 1. Click **SpawnHunt** on the title screen
 2. You're shown a random target item — **Reroll** for a new one, or pick from the full **List**
@@ -10,13 +12,20 @@
 4. Find and collect the target item as fast as possible
 5. Your time is tracked, and your best runs are saved per item
 
+### Multiplayer
+
+1. Install SpawnHunt on your Fabric server (players don't need the mod installed)
+2. An OP runs `/spawnhunt start random` or `/spawnhunt start <item>`
+3. All players race to find the target item first
+4. Players with the mod see a rich HUD; players without see action bar messages
+5. The first player to collect the item wins
+
 ## Features
 
 - **400+ target items** — every survival-obtainable item in the game
-- **Built-in timer** — pause-aware, displayed in the HUD alongside your target
-- **Run history** — tracks your last three and top three times for each item
-- **Hardcore mode** — optional toggle for an extra challenge
-- **Zero setup** — worlds are created automatically with a single click
+- **Singleplayer** — built-in timer with pause awareness, run history, hardcore mode
+- **Multiplayer** — server commands, automatic inventory scanning, works with vanilla clients
+- **Zero setup** — singleplayer worlds created with a single click; multiplayer via one command
 
 ## Requirements
 
@@ -26,9 +35,27 @@
 
 ## Installation
 
+### Client (singleplayer + enhanced multiplayer HUD)
 1. Install Fabric Loader and Fabric API for Minecraft 1.21.11
 2. Drop the `spawnhunt` jar into your `mods` folder
 3. Launch the game — the **SpawnHunt** button appears on the title screen
+
+### Server (multiplayer)
+1. Install Fabric Loader and Fabric API on your server
+2. Drop the `spawnhunt` jar into the server's `mods` folder
+3. Start the server — `/spawnhunt` commands are available to OPs
+
+Players **do not** need the mod installed to participate. They'll see the hunt via action bar messages and chat. Players with the mod get a richer HUD experience.
+
+## Commands
+
+| Command | Permission | Description |
+|---------|-----------|-------------|
+| `/spawnhunt start random` | OP | Start a hunt with a random item |
+| `/spawnhunt start <item>` | OP | Start a hunt with a specific item (tab-completable) |
+| `/spawnhunt stop` | OP | Cancel the current hunt |
+| `/spawnhunt restart [item]` | OP | Stop and start a new hunt |
+| `/spawnhunt status` | Everyone | Show current hunt info |
 
 ## Community & Support
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.21.11+build.4
 loader_version=0.18.4
 
 # Mod Properties
-mod_version=1.3.0
+mod_version=2.0.0
 maven_group=com.spawnhunt
 archives_base_name=spawnhunt
 

--- a/src/main/java/com/spawnhunt/SpawnHuntCommon.java
+++ b/src/main/java/com/spawnhunt/SpawnHuntCommon.java
@@ -1,0 +1,31 @@
+package com.spawnhunt;
+
+import com.spawnhunt.command.SpawnHuntCommand;
+import com.spawnhunt.event.ServerHuntManager;
+import com.spawnhunt.network.SpawnHuntPayloads;
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SpawnHuntCommon implements ModInitializer {
+    public static final Logger LOGGER = LoggerFactory.getLogger("spawnhunt");
+
+    @Override
+    public void onInitialize() {
+        LOGGER.info("SpawnHunt common initializing...");
+
+        // Register custom packet types (must happen before networking is used)
+        SpawnHuntPayloads.register();
+
+        // Register /spawnhunt commands
+        CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> {
+            SpawnHuntCommand.register(dispatcher);
+        });
+
+        // Register server tick handler for multiplayer hunt management
+        ServerHuntManager.register();
+
+        LOGGER.info("SpawnHunt common initialized!");
+    }
+}

--- a/src/main/java/com/spawnhunt/SpawnHuntMod.java
+++ b/src/main/java/com/spawnhunt/SpawnHuntMod.java
@@ -5,12 +5,17 @@ import com.spawnhunt.data.HuntState;
 import com.spawnhunt.event.InventoryListener;
 import com.spawnhunt.event.WorldLifecycleHandler;
 import com.spawnhunt.hud.HuntHudRenderer;
+import com.spawnhunt.network.ClientHuntState;
+import com.spawnhunt.network.HuntSyncS2CPayload;
+import com.spawnhunt.network.HuntWinS2CPayload;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback;
 import net.minecraft.client.gui.screen.DeathScreen;
+import net.minecraft.sound.SoundEvents;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,6 +52,20 @@ public class SpawnHuntMod implements ClientModInitializer {
 
         // Render the HUD overlay (target block + timer)
         HudRenderCallback.EVENT.register(HuntHudRenderer::render);
+
+        // Register multiplayer packet receivers
+        ClientPlayNetworking.registerGlobalReceiver(HuntSyncS2CPayload.ID, (payload, context) -> {
+            context.client().execute(() -> ClientHuntState.update(payload));
+        });
+
+        ClientPlayNetworking.registerGlobalReceiver(HuntWinS2CPayload.ID, (payload, context) -> {
+            context.client().execute(() -> {
+                ClientHuntState.handleWin(payload);
+                if (context.client().player != null) {
+                    context.client().player.playSound(SoundEvents.UI_TOAST_CHALLENGE_COMPLETE, 1.0f, 1.0f);
+                }
+            });
+        });
 
         LOGGER.info("SpawnHunt initialized!");
     }

--- a/src/main/java/com/spawnhunt/command/SpawnHuntCommand.java
+++ b/src/main/java/com/spawnhunt/command/SpawnHuntCommand.java
@@ -68,7 +68,9 @@ public class SpawnHuntCommand {
             context.getSource().sendError(Text.literal("A hunt is already active! Use /spawnhunt stop first."));
             return 0;
         }
-        return resolveAndStart(context);
+        Item item = resolveItem(context);
+        if (item == null) return 0;
+        return doStart(context, item);
     }
 
     private static int stop(CommandContext<ServerCommandSource> context) {
@@ -93,28 +95,28 @@ public class SpawnHuntCommand {
     }
 
     private static int restartSpecific(CommandContext<ServerCommandSource> context) {
-        return resolveAndStart(context);
+        Item item = resolveItem(context);
+        if (item == null) return 0;
+        doStop(context);
+        return doStart(context, item);
     }
 
-    private static int resolveAndStart(CommandContext<ServerCommandSource> context) {
+    private static Item resolveItem(CommandContext<ServerCommandSource> context) {
         Identifier itemId = IdentifierArgumentType.getIdentifier(context, "item");
 
         if (!Registries.ITEM.containsId(itemId)) {
             context.getSource().sendError(Text.literal("Unknown item: " + itemId));
-            return 0;
+            return null;
         }
 
         Item item = Registries.ITEM.get(itemId);
 
         if (!ItemPool.getPool().contains(item)) {
             context.getSource().sendError(Text.literal("Item not in the SpawnHunt pool: " + itemId));
-            return 0;
+            return null;
         }
 
-        if (ServerHuntState.isActive()) {
-            doStop(context);
-        }
-        return doStart(context, item);
+        return item;
     }
 
     private static int doStart(CommandContext<ServerCommandSource> context, Item item) {

--- a/src/main/java/com/spawnhunt/command/SpawnHuntCommand.java
+++ b/src/main/java/com/spawnhunt/command/SpawnHuntCommand.java
@@ -1,0 +1,205 @@
+package com.spawnhunt.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.context.CommandContext;
+import com.spawnhunt.data.ItemPool;
+import com.spawnhunt.data.HuntState;
+import com.spawnhunt.data.ServerHuntState;
+import com.spawnhunt.event.ServerHuntManager;
+import net.minecraft.command.argument.IdentifierArgumentType;
+import net.minecraft.command.permission.Permission;
+import net.minecraft.command.permission.PermissionLevel;
+import net.minecraft.item.Item;
+import net.minecraft.registry.Registries;
+import net.minecraft.server.command.CommandManager;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import net.minecraft.util.Identifier;
+
+import java.util.Random;
+
+public class SpawnHuntCommand {
+
+    private static final Random RANDOM = new Random();
+
+    public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
+        dispatcher.register(CommandManager.literal("spawnhunt")
+                .then(CommandManager.literal("start")
+                        .requires(source -> source.getPermissions().hasPermission(new Permission.Level(PermissionLevel.GAMEMASTERS)))
+                        .then(CommandManager.literal("random")
+                                .executes(SpawnHuntCommand::startRandom))
+                        .then(CommandManager.argument("item", IdentifierArgumentType.identifier())
+                                .suggests((context, builder) -> {
+                                    String remaining = builder.getRemaining().toLowerCase();
+                                    for (Item item : ItemPool.getPool()) {
+                                        String id = Registries.ITEM.getId(item).toString();
+                                        if (id.startsWith(remaining) || id.startsWith("minecraft:" + remaining)) {
+                                            builder.suggest(id);
+                                        }
+                                    }
+                                    return builder.buildFuture();
+                                })
+                                .executes(SpawnHuntCommand::startSpecific)))
+                .then(CommandManager.literal("stop")
+                        .requires(source -> source.getPermissions().hasPermission(new Permission.Level(PermissionLevel.GAMEMASTERS)))
+                        .executes(SpawnHuntCommand::stop))
+                .then(CommandManager.literal("restart")
+                        .requires(source -> source.getPermissions().hasPermission(new Permission.Level(PermissionLevel.GAMEMASTERS)))
+                        .executes(SpawnHuntCommand::restartRandom)
+                        .then(CommandManager.argument("item", IdentifierArgumentType.identifier())
+                                .suggests((context, builder) -> {
+                                    String remaining = builder.getRemaining().toLowerCase();
+                                    for (Item item : ItemPool.getPool()) {
+                                        String id = Registries.ITEM.getId(item).toString();
+                                        if (id.startsWith(remaining) || id.startsWith("minecraft:" + remaining)) {
+                                            builder.suggest(id);
+                                        }
+                                    }
+                                    return builder.buildFuture();
+                                })
+                                .executes(SpawnHuntCommand::restartSpecific)))
+                .then(CommandManager.literal("status")
+                        .executes(SpawnHuntCommand::status)));
+    }
+
+    private static int startRandom(CommandContext<ServerCommandSource> context) {
+        if (ServerHuntState.isActive()) {
+            context.getSource().sendError(Text.literal("A hunt is already active! Use /spawnhunt stop first."));
+            return 0;
+        }
+
+        Item item = ItemPool.getRandomItem(RANDOM);
+        Identifier itemId = Registries.ITEM.getId(item);
+        ServerHuntState.start(itemId);
+
+        Text itemName = ItemPool.getDisplayName(item);
+        Text message = Text.empty()
+                .append(Text.literal("[SpawnHunt] ").formatted(Formatting.GOLD))
+                .append(Text.literal("Hunt started! Find: ").formatted(Formatting.YELLOW))
+                .append(Text.literal(itemName.getString()).formatted(Formatting.AQUA));
+
+        ServerHuntManager.broadcastMessage(context.getSource().getServer(), message);
+        return 1;
+    }
+
+    private static int startSpecific(CommandContext<ServerCommandSource> context) {
+        if (ServerHuntState.isActive()) {
+            context.getSource().sendError(Text.literal("A hunt is already active! Use /spawnhunt stop first."));
+            return 0;
+        }
+
+        Identifier itemId = IdentifierArgumentType.getIdentifier(context, "item");
+        Item item = Registries.ITEM.get(itemId);
+
+        if (!ItemPool.getPool().contains(item)) {
+            context.getSource().sendError(Text.literal("Item not in the SpawnHunt pool: " + itemId));
+            return 0;
+        }
+
+        ServerHuntState.start(itemId);
+
+        Text itemName = ItemPool.getDisplayName(item);
+        Text message = Text.empty()
+                .append(Text.literal("[SpawnHunt] ").formatted(Formatting.GOLD))
+                .append(Text.literal("Hunt started! Find: ").formatted(Formatting.YELLOW))
+                .append(Text.literal(itemName.getString()).formatted(Formatting.AQUA));
+
+        ServerHuntManager.broadcastMessage(context.getSource().getServer(), message);
+        return 1;
+    }
+
+    private static int stop(CommandContext<ServerCommandSource> context) {
+        if (!ServerHuntState.isActive()) {
+            context.getSource().sendError(Text.literal("No hunt is currently active."));
+            return 0;
+        }
+
+        ServerHuntState.stop();
+
+        Text message = Text.empty()
+                .append(Text.literal("[SpawnHunt] ").formatted(Formatting.GOLD))
+                .append(Text.literal("Hunt stopped.").formatted(Formatting.RED));
+
+        ServerHuntManager.broadcastMessage(context.getSource().getServer(), message);
+        ServerHuntManager.sendStopSync(context.getSource().getServer());
+        return 1;
+    }
+
+    private static int restartRandom(CommandContext<ServerCommandSource> context) {
+        ServerHuntState.stop();
+        ServerHuntManager.sendStopSync(context.getSource().getServer());
+
+        Item item = ItemPool.getRandomItem(RANDOM);
+        Identifier itemId = Registries.ITEM.getId(item);
+        ServerHuntState.start(itemId);
+
+        Text itemName = ItemPool.getDisplayName(item);
+        Text message = Text.empty()
+                .append(Text.literal("[SpawnHunt] ").formatted(Formatting.GOLD))
+                .append(Text.literal("New hunt! Find: ").formatted(Formatting.YELLOW))
+                .append(Text.literal(itemName.getString()).formatted(Formatting.AQUA));
+
+        ServerHuntManager.broadcastMessage(context.getSource().getServer(), message);
+        return 1;
+    }
+
+    private static int restartSpecific(CommandContext<ServerCommandSource> context) {
+        Identifier itemId = IdentifierArgumentType.getIdentifier(context, "item");
+        Item item = Registries.ITEM.get(itemId);
+
+        if (!ItemPool.getPool().contains(item)) {
+            context.getSource().sendError(Text.literal("Item not in the SpawnHunt pool: " + itemId));
+            return 0;
+        }
+
+        ServerHuntState.stop();
+        ServerHuntManager.sendStopSync(context.getSource().getServer());
+        ServerHuntState.start(itemId);
+
+        Text itemName = ItemPool.getDisplayName(item);
+        Text message = Text.empty()
+                .append(Text.literal("[SpawnHunt] ").formatted(Formatting.GOLD))
+                .append(Text.literal("New hunt! Find: ").formatted(Formatting.YELLOW))
+                .append(Text.literal(itemName.getString()).formatted(Formatting.AQUA));
+
+        ServerHuntManager.broadcastMessage(context.getSource().getServer(), message);
+        return 1;
+    }
+
+    private static int status(CommandContext<ServerCommandSource> context) {
+        if (!ServerHuntState.isActive()) {
+            context.getSource().sendFeedback(() -> Text.literal("[SpawnHunt] No hunt active.").formatted(Formatting.GRAY), false);
+            return 1;
+        }
+
+        Identifier targetId = ServerHuntState.getTargetItem();
+        Item item = Registries.ITEM.get(targetId);
+        Text itemName = ItemPool.getDisplayName(item);
+        String timeStr = HuntState.formatTimeSeconds(ServerHuntState.getElapsedMs());
+        int playerCount = context.getSource().getServer().getCurrentPlayerCount();
+
+        Text status;
+        if (ServerHuntState.isWon()) {
+            status = Text.empty()
+                    .append(Text.literal("[SpawnHunt] ").formatted(Formatting.GOLD))
+                    .append(Text.literal(ServerHuntState.getWinnerName()).formatted(Formatting.GREEN))
+                    .append(Text.literal(" found ").formatted(Formatting.YELLOW))
+                    .append(Text.literal(itemName.getString()).formatted(Formatting.AQUA))
+                    .append(Text.literal(" in ").formatted(Formatting.YELLOW))
+                    .append(Text.literal(HuntState.formatTimeSeconds(ServerHuntState.getFinalTimeMs())).formatted(Formatting.WHITE));
+        } else {
+            status = Text.empty()
+                    .append(Text.literal("[SpawnHunt] ").formatted(Formatting.GOLD))
+                    .append(Text.literal("Target: ").formatted(Formatting.YELLOW))
+                    .append(Text.literal(itemName.getString()).formatted(Formatting.AQUA))
+                    .append(Text.literal(" | Time: ").formatted(Formatting.YELLOW))
+                    .append(Text.literal(timeStr).formatted(Formatting.WHITE))
+                    .append(Text.literal(" | Players: ").formatted(Formatting.YELLOW))
+                    .append(Text.literal(String.valueOf(playerCount)).formatted(Formatting.WHITE));
+        }
+
+        context.getSource().sendFeedback(() -> status, false);
+        return 1;
+    }
+}

--- a/src/main/java/com/spawnhunt/command/SpawnHuntCommand.java
+++ b/src/main/java/com/spawnhunt/command/SpawnHuntCommand.java
@@ -2,6 +2,7 @@ package com.spawnhunt.command;
 
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.spawnhunt.data.ItemPool;
 import com.spawnhunt.data.HuntState;
 import com.spawnhunt.data.ServerHuntState;
@@ -17,11 +18,20 @@ import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class SpawnHuntCommand {
 
-    private static final Random RANDOM = new Random();
+    private static final SuggestionProvider<ServerCommandSource> ITEM_SUGGESTIONS = (context, builder) -> {
+        String remaining = builder.getRemaining().toLowerCase();
+        for (Item item : ItemPool.getPool()) {
+            String id = Registries.ITEM.getId(item).toString();
+            if (id.startsWith(remaining) || id.startsWith("minecraft:" + remaining)) {
+                builder.suggest(id);
+            }
+        }
+        return builder.buildFuture();
+    };
 
     public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
         dispatcher.register(CommandManager.literal("spawnhunt")
@@ -30,16 +40,7 @@ public class SpawnHuntCommand {
                         .then(CommandManager.literal("random")
                                 .executes(SpawnHuntCommand::startRandom))
                         .then(CommandManager.argument("item", IdentifierArgumentType.identifier())
-                                .suggests((context, builder) -> {
-                                    String remaining = builder.getRemaining().toLowerCase();
-                                    for (Item item : ItemPool.getPool()) {
-                                        String id = Registries.ITEM.getId(item).toString();
-                                        if (id.startsWith(remaining) || id.startsWith("minecraft:" + remaining)) {
-                                            builder.suggest(id);
-                                        }
-                                    }
-                                    return builder.buildFuture();
-                                })
+                                .suggests(ITEM_SUGGESTIONS)
                                 .executes(SpawnHuntCommand::startSpecific)))
                 .then(CommandManager.literal("stop")
                         .requires(source -> source.getPermissions().hasPermission(new Permission.Level(PermissionLevel.GAMEMASTERS)))
@@ -48,16 +49,7 @@ public class SpawnHuntCommand {
                         .requires(source -> source.getPermissions().hasPermission(new Permission.Level(PermissionLevel.GAMEMASTERS)))
                         .executes(SpawnHuntCommand::restartRandom)
                         .then(CommandManager.argument("item", IdentifierArgumentType.identifier())
-                                .suggests((context, builder) -> {
-                                    String remaining = builder.getRemaining().toLowerCase();
-                                    for (Item item : ItemPool.getPool()) {
-                                        String id = Registries.ITEM.getId(item).toString();
-                                        if (id.startsWith(remaining) || id.startsWith("minecraft:" + remaining)) {
-                                            builder.suggest(id);
-                                        }
-                                    }
-                                    return builder.buildFuture();
-                                })
+                                .suggests(ITEM_SUGGESTIONS)
                                 .executes(SpawnHuntCommand::restartSpecific)))
                 .then(CommandManager.literal("status")
                         .executes(SpawnHuntCommand::status)));
@@ -68,19 +60,7 @@ public class SpawnHuntCommand {
             context.getSource().sendError(Text.literal("A hunt is already active! Use /spawnhunt stop first."));
             return 0;
         }
-
-        Item item = ItemPool.getRandomItem(RANDOM);
-        Identifier itemId = Registries.ITEM.getId(item);
-        ServerHuntState.start(itemId);
-
-        Text itemName = ItemPool.getDisplayName(item);
-        Text message = Text.empty()
-                .append(Text.literal("[SpawnHunt] ").formatted(Formatting.GOLD))
-                .append(Text.literal("Hunt started! Find: ").formatted(Formatting.YELLOW))
-                .append(Text.literal(itemName.getString()).formatted(Formatting.AQUA));
-
-        ServerHuntManager.broadcastMessage(context.getSource().getServer(), message);
-        return 1;
+        return doStart(context, ItemPool.getRandomItem(ThreadLocalRandom.current()));
     }
 
     private static int startSpecific(CommandContext<ServerCommandSource> context) {
@@ -88,25 +68,7 @@ public class SpawnHuntCommand {
             context.getSource().sendError(Text.literal("A hunt is already active! Use /spawnhunt stop first."));
             return 0;
         }
-
-        Identifier itemId = IdentifierArgumentType.getIdentifier(context, "item");
-        Item item = Registries.ITEM.get(itemId);
-
-        if (!ItemPool.getPool().contains(item)) {
-            context.getSource().sendError(Text.literal("Item not in the SpawnHunt pool: " + itemId));
-            return 0;
-        }
-
-        ServerHuntState.start(itemId);
-
-        Text itemName = ItemPool.getDisplayName(item);
-        Text message = Text.empty()
-                .append(Text.literal("[SpawnHunt] ").formatted(Formatting.GOLD))
-                .append(Text.literal("Hunt started! Find: ").formatted(Formatting.YELLOW))
-                .append(Text.literal(itemName.getString()).formatted(Formatting.AQUA));
-
-        ServerHuntManager.broadcastMessage(context.getSource().getServer(), message);
-        return 1;
+        return resolveAndStart(context);
     }
 
     private static int stop(CommandContext<ServerCommandSource> context) {
@@ -115,37 +77,33 @@ public class SpawnHuntCommand {
             return 0;
         }
 
-        ServerHuntState.stop();
+        doStop(context);
 
         Text message = Text.empty()
                 .append(Text.literal("[SpawnHunt] ").formatted(Formatting.GOLD))
                 .append(Text.literal("Hunt stopped.").formatted(Formatting.RED));
 
         ServerHuntManager.broadcastMessage(context.getSource().getServer(), message);
-        ServerHuntManager.sendStopSync(context.getSource().getServer());
         return 1;
     }
 
     private static int restartRandom(CommandContext<ServerCommandSource> context) {
-        ServerHuntState.stop();
-        ServerHuntManager.sendStopSync(context.getSource().getServer());
-
-        Item item = ItemPool.getRandomItem(RANDOM);
-        Identifier itemId = Registries.ITEM.getId(item);
-        ServerHuntState.start(itemId);
-
-        Text itemName = ItemPool.getDisplayName(item);
-        Text message = Text.empty()
-                .append(Text.literal("[SpawnHunt] ").formatted(Formatting.GOLD))
-                .append(Text.literal("New hunt! Find: ").formatted(Formatting.YELLOW))
-                .append(Text.literal(itemName.getString()).formatted(Formatting.AQUA));
-
-        ServerHuntManager.broadcastMessage(context.getSource().getServer(), message);
-        return 1;
+        doStop(context);
+        return doStart(context, ItemPool.getRandomItem(ThreadLocalRandom.current()));
     }
 
     private static int restartSpecific(CommandContext<ServerCommandSource> context) {
+        return resolveAndStart(context);
+    }
+
+    private static int resolveAndStart(CommandContext<ServerCommandSource> context) {
         Identifier itemId = IdentifierArgumentType.getIdentifier(context, "item");
+
+        if (!Registries.ITEM.containsId(itemId)) {
+            context.getSource().sendError(Text.literal("Unknown item: " + itemId));
+            return 0;
+        }
+
         Item item = Registries.ITEM.get(itemId);
 
         if (!ItemPool.getPool().contains(item)) {
@@ -153,18 +111,29 @@ public class SpawnHuntCommand {
             return 0;
         }
 
-        ServerHuntState.stop();
-        ServerHuntManager.sendStopSync(context.getSource().getServer());
+        if (ServerHuntState.isActive()) {
+            doStop(context);
+        }
+        return doStart(context, item);
+    }
+
+    private static int doStart(CommandContext<ServerCommandSource> context, Item item) {
+        Identifier itemId = Registries.ITEM.getId(item);
         ServerHuntState.start(itemId);
 
         Text itemName = ItemPool.getDisplayName(item);
         Text message = Text.empty()
                 .append(Text.literal("[SpawnHunt] ").formatted(Formatting.GOLD))
-                .append(Text.literal("New hunt! Find: ").formatted(Formatting.YELLOW))
+                .append(Text.literal("Hunt started! Find: ").formatted(Formatting.YELLOW))
                 .append(Text.literal(itemName.getString()).formatted(Formatting.AQUA));
 
         ServerHuntManager.broadcastMessage(context.getSource().getServer(), message);
         return 1;
+    }
+
+    private static void doStop(CommandContext<ServerCommandSource> context) {
+        ServerHuntState.stop();
+        ServerHuntManager.sendStopSync(context.getSource().getServer());
     }
 
     private static int status(CommandContext<ServerCommandSource> context) {

--- a/src/main/java/com/spawnhunt/data/HuntState.java
+++ b/src/main/java/com/spawnhunt/data/HuntState.java
@@ -72,4 +72,11 @@ public class HuntState {
         long millis = ms % 1000;
         return String.format("%02d:%02d.%03d", minutes, seconds, millis);
     }
+
+    public static String formatTimeSeconds(long ms) {
+        long totalSeconds = ms / 1000;
+        long minutes = totalSeconds / 60;
+        long seconds = totalSeconds % 60;
+        return String.format("%02d:%02d", minutes, seconds);
+    }
 }

--- a/src/main/java/com/spawnhunt/data/ServerHuntState.java
+++ b/src/main/java/com/spawnhunt/data/ServerHuntState.java
@@ -1,0 +1,62 @@
+package com.spawnhunt.data;
+
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+
+import java.util.UUID;
+
+/**
+ * Server-authoritative hunt state for multiplayer.
+ * Uses wall-clock timing (no pause concept in multiplayer).
+ */
+public class ServerHuntState {
+    private static boolean active = false;
+    private static Identifier targetItem = null;
+    private static long startTimeMs = 0;
+    private static boolean won = false;
+    private static UUID winnerUuid = null;
+    private static String winnerName = "";
+    private static long finalTimeMs = 0;
+
+    public static void start(Identifier item) {
+        reset();
+        active = true;
+        targetItem = item;
+        startTimeMs = System.currentTimeMillis();
+    }
+
+    public static void stop() {
+        reset();
+    }
+
+    public static void win(ServerPlayerEntity player) {
+        if (!active || won) return;
+        finalTimeMs = System.currentTimeMillis() - startTimeMs;
+        won = true;
+        winnerUuid = player.getUuid();
+        winnerName = player.getName().getString();
+    }
+
+    public static void reset() {
+        active = false;
+        targetItem = null;
+        startTimeMs = 0;
+        won = false;
+        winnerUuid = null;
+        winnerName = "";
+        finalTimeMs = 0;
+    }
+
+    public static long getElapsedMs() {
+        if (!active) return 0;
+        if (won) return finalTimeMs;
+        return System.currentTimeMillis() - startTimeMs;
+    }
+
+    public static boolean isActive() { return active; }
+    public static Identifier getTargetItem() { return targetItem; }
+    public static boolean isWon() { return won; }
+    public static UUID getWinnerUuid() { return winnerUuid; }
+    public static String getWinnerName() { return winnerName; }
+    public static long getFinalTimeMs() { return finalTimeMs; }
+}

--- a/src/main/java/com/spawnhunt/event/ServerHuntManager.java
+++ b/src/main/java/com/spawnhunt/event/ServerHuntManager.java
@@ -106,8 +106,9 @@ public class ServerHuntManager {
         for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
             if (ServerPlayNetworking.canSend(player, HuntWinS2CPayload.ID)) {
                 ServerPlayNetworking.send(player, winPayload);
+            } else {
+                player.playSound(SoundEvents.UI_TOAST_CHALLENGE_COMPLETE, 1.0f, 1.0f);
             }
-            player.playSound(SoundEvents.UI_TOAST_CHALLENGE_COMPLETE, 1.0f, 1.0f);
         }
 
         // Send final sync to mod clients

--- a/src/main/java/com/spawnhunt/event/ServerHuntManager.java
+++ b/src/main/java/com/spawnhunt/event/ServerHuntManager.java
@@ -1,0 +1,181 @@
+package com.spawnhunt.event;
+
+import com.spawnhunt.data.HuntState;
+import com.spawnhunt.data.ItemPool;
+import com.spawnhunt.data.ServerHuntState;
+import com.spawnhunt.network.HuntSyncS2CPayload;
+import com.spawnhunt.network.HuntWinS2CPayload;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.registry.Registries;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.sound.SoundEvents;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import net.minecraft.util.Identifier;
+
+public class ServerHuntManager {
+
+    private static int tickCounter = 0;
+
+    public static void register() {
+        ServerTickEvents.END_SERVER_TICK.register(ServerHuntManager::onServerTick);
+
+        ServerPlayConnectionEvents.JOIN.register((handler, sender, server) -> {
+            if (ServerHuntState.isActive()) {
+                ServerPlayerEntity player = handler.getPlayer();
+                if (ServerPlayNetworking.canSend(player, HuntSyncS2CPayload.ID)) {
+                    ServerPlayNetworking.send(player, buildSyncPayload());
+                }
+            }
+        });
+    }
+
+    private static void onServerTick(MinecraftServer server) {
+        if (!ServerHuntState.isActive()) {
+            tickCounter = 0;
+            return;
+        }
+
+        tickCounter++;
+
+        // Scan inventories for win detection (every tick when hunt is active and not won)
+        if (!ServerHuntState.isWon()) {
+            scanInventories(server);
+        }
+
+        // Broadcast to mod clients every 5 ticks (~250ms)
+        if (tickCounter % 5 == 0) {
+            broadcastSyncToModClients(server);
+        }
+
+        // Broadcast to vanilla clients every 20 ticks (~1 second)
+        if (tickCounter % 20 == 0) {
+            broadcastActionBarToVanillaClients(server);
+        }
+    }
+
+    private static void scanInventories(MinecraftServer server) {
+        Identifier targetId = ServerHuntState.getTargetItem();
+        if (targetId == null) return;
+
+        Item targetItem = Registries.ITEM.get(targetId);
+
+        for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+            for (int i = 0; i < player.getInventory().size(); i++) {
+                ItemStack stack = player.getInventory().getStack(i);
+                if (!stack.isEmpty() && stack.getItem() == targetItem) {
+                    handleWin(server, player);
+                    return;
+                }
+            }
+        }
+    }
+
+    private static void handleWin(MinecraftServer server, ServerPlayerEntity winner) {
+        ServerHuntState.win(winner);
+
+        Identifier targetId = ServerHuntState.getTargetItem();
+        Item item = Registries.ITEM.get(targetId);
+        Text itemName = ItemPool.getDisplayName(item);
+        String timeStr = HuntState.formatTimeSeconds(ServerHuntState.getFinalTimeMs());
+
+        // Chat message to all players
+        Text winMessage = Text.empty()
+                .append(Text.literal("[SpawnHunt] ").formatted(Formatting.GOLD))
+                .append(Text.literal(winner.getName().getString()).formatted(Formatting.GREEN))
+                .append(Text.literal(" found ").formatted(Formatting.YELLOW))
+                .append(Text.literal(itemName.getString()).formatted(Formatting.AQUA))
+                .append(Text.literal(" in ").formatted(Formatting.YELLOW))
+                .append(Text.literal(timeStr).formatted(Formatting.GREEN))
+                .append(Text.literal("!").formatted(Formatting.YELLOW));
+
+        broadcastMessage(server, winMessage);
+
+        // Send win packet to mod clients + play sound for all
+        HuntWinS2CPayload winPayload = new HuntWinS2CPayload(
+                winner.getName().getString(),
+                ServerHuntState.getFinalTimeMs(),
+                targetId.toString()
+        );
+
+        for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+            if (ServerPlayNetworking.canSend(player, HuntWinS2CPayload.ID)) {
+                ServerPlayNetworking.send(player, winPayload);
+            }
+            player.playSound(SoundEvents.UI_TOAST_CHALLENGE_COMPLETE, 1.0f, 1.0f);
+        }
+
+        // Send final sync to mod clients
+        broadcastSyncToModClients(server);
+    }
+
+    private static void broadcastSyncToModClients(MinecraftServer server) {
+        HuntSyncS2CPayload payload = buildSyncPayload();
+        for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+            if (ServerPlayNetworking.canSend(player, HuntSyncS2CPayload.ID)) {
+                ServerPlayNetworking.send(player, payload);
+            }
+        }
+    }
+
+    private static void broadcastActionBarToVanillaClients(MinecraftServer server) {
+        if (!ServerHuntState.isActive() || ServerHuntState.isWon()) return;
+
+        Identifier targetId = ServerHuntState.getTargetItem();
+        if (targetId == null) return;
+
+        Item item = Registries.ITEM.get(targetId);
+        Text itemName = ItemPool.getDisplayName(item);
+        String timeStr = HuntState.formatTimeSeconds(ServerHuntState.getElapsedMs());
+
+        Text actionBar = Text.empty()
+                .append(Text.literal("SpawnHunt").formatted(Formatting.GOLD))
+                .append(Text.literal(" | ").formatted(Formatting.GRAY))
+                .append(Text.literal(itemName.getString()).formatted(Formatting.AQUA))
+                .append(Text.literal(" | ").formatted(Formatting.GRAY))
+                .append(Text.literal(timeStr).formatted(Formatting.WHITE));
+
+        for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+            if (!ServerPlayNetworking.canSend(player, HuntSyncS2CPayload.ID)) {
+                player.sendMessage(actionBar, true);
+            }
+        }
+    }
+
+    private static HuntSyncS2CPayload buildSyncPayload() {
+        return new HuntSyncS2CPayload(
+                ServerHuntState.isActive(),
+                ServerHuntState.getTargetItem() != null ? ServerHuntState.getTargetItem().toString() : "",
+                ServerHuntState.getElapsedMs(),
+                ServerHuntState.isWon(),
+                ServerHuntState.getWinnerName(),
+                ServerHuntState.getFinalTimeMs()
+        );
+    }
+
+    /**
+     * Sends an inactive sync payload to all mod clients (used when hunt is stopped).
+     */
+    public static void sendStopSync(MinecraftServer server) {
+        HuntSyncS2CPayload payload = new HuntSyncS2CPayload(false, "", 0, false, "", 0);
+        for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+            if (ServerPlayNetworking.canSend(player, HuntSyncS2CPayload.ID)) {
+                ServerPlayNetworking.send(player, payload);
+            }
+        }
+    }
+
+    /**
+     * Sends a chat message to all players on the server.
+     */
+    public static void broadcastMessage(MinecraftServer server, Text message) {
+        for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+            player.sendMessage(message, false);
+        }
+    }
+}

--- a/src/main/java/com/spawnhunt/event/WorldLifecycleHandler.java
+++ b/src/main/java/com/spawnhunt/event/WorldLifecycleHandler.java
@@ -2,6 +2,7 @@ package com.spawnhunt.event;
 
 import com.spawnhunt.SpawnHuntMod;
 import com.spawnhunt.data.HuntState;
+import com.spawnhunt.network.ClientHuntState;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 
 public class WorldLifecycleHandler {
@@ -12,6 +13,7 @@ public class WorldLifecycleHandler {
                 SpawnHuntMod.LOGGER.info("SpawnHunt: hunt ended (disconnected from world)");
                 HuntState.reset();
             }
+            ClientHuntState.reset();
         });
     }
 }

--- a/src/main/java/com/spawnhunt/hud/HuntHudRenderer.java
+++ b/src/main/java/com/spawnhunt/hud/HuntHudRenderer.java
@@ -2,6 +2,7 @@ package com.spawnhunt.hud;
 
 import com.spawnhunt.data.HuntState;
 import com.spawnhunt.data.ResultStore;
+import com.spawnhunt.network.ClientHuntState;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
@@ -23,29 +24,45 @@ public class HuntHudRenderer {
     private static final int WIN_NAME_COLOR = 0xFF55FF55;
 
     public static void render(DrawContext context, RenderTickCounter tickCounter) {
-        if (!HuntState.isActive()) return;
-
         MinecraftClient client = MinecraftClient.getInstance();
         if (client.player == null) return;
 
-        TextRenderer textRenderer = client.textRenderer;
-        renderHudBlock(context, textRenderer);
+        // Multiplayer (server-authoritative) takes priority
+        if (ClientHuntState.isActive()) {
+            renderHud(context, client.textRenderer,
+                    ClientHuntState.getTargetItem(),
+                    ClientHuntState.isWon(),
+                    ClientHuntState.isWon() ? ClientHuntState.getFinalTimeMs() : ClientHuntState.getElapsedMs(),
+                    ClientHuntState.isWon() ? ClientHuntState.getWinnerName() : null,
+                    false);
+            return;
+        }
+
+        // Singleplayer fallback
+        if (HuntState.isActive()) {
+            renderHud(context, client.textRenderer,
+                    HuntState.getTargetItem(),
+                    HuntState.isWon(),
+                    HuntState.isWon() ? HuntState.getFinalTimeMs() : HuntState.getAccumulatedMs(),
+                    null,
+                    true);
+        }
     }
 
-    private static void renderHudBlock(DrawContext context, TextRenderer textRenderer) {
-        Identifier targetId = HuntState.getTargetItem();
+    private static void renderHud(DrawContext context, TextRenderer textRenderer,
+                                   Identifier targetId, boolean won, long timeMs,
+                                   String winnerName, boolean singleplayer) {
         if (targetId == null) return;
 
         Item item = Registries.ITEM.get(targetId);
         ItemStack stack = new ItemStack(item);
         Text itemName = ItemPool.getDisplayName(item);
-        boolean won = HuntState.isWon();
 
         int screenWidth = MinecraftClient.getInstance().getWindow().getScaledWidth();
         int centreX = screenWidth / 2;
         int y = TOP_MARGIN;
 
-        // Item icon — centred at top, pinned to screen edge
+        // Item icon — centred at top
         context.drawItem(stack, centreX - 8, y);
         y += 16 + LINE_GAP;
 
@@ -56,8 +73,7 @@ public class HuntHudRenderer {
         y += textRenderer.fontHeight + LINE_GAP;
 
         // Timer — centred below name, larger on win
-        long ms = won ? HuntState.getFinalTimeMs() : HuntState.getAccumulatedMs();
-        String timeStr = HuntState.formatTime(ms);
+        String timeStr = singleplayer ? HuntState.formatTime(timeMs) : HuntState.formatTimeSeconds(timeMs);
         if (won) {
             float timerWidthF = textRenderer.getWidth(timeStr) * WIN_TIMER_SCALE;
             context.getMatrices().pushMatrix();
@@ -72,16 +88,27 @@ public class HuntHudRenderer {
             y += textRenderer.fontHeight + LINE_GAP;
         }
 
-        // Best time — centred below timer
-        long bestTimeMs = ResultStore.getBestTime(targetId);
-        if (bestTimeMs >= 0) {
-            String bestStr = "Best: " + HuntState.formatTime(bestTimeMs);
-            float bestWidthF = textRenderer.getWidth(bestStr) * BEST_SCALE;
-            context.getMatrices().pushMatrix();
-            context.getMatrices().translate(centreX - bestWidthF / 2f, (float) y);
-            context.getMatrices().scale(BEST_SCALE, BEST_SCALE);
-            context.drawText(textRenderer, bestStr, 0, 0, BEST_COLOR, true);
-            context.getMatrices().popMatrix();
+        // Winner name (multiplayer only)
+        if (won && winnerName != null && !winnerName.isEmpty()) {
+            String winText = winnerName + " wins!";
+            int winWidth = textRenderer.getWidth(winText);
+            context.drawText(textRenderer, winText,
+                    centreX - winWidth / 2, y, WIN_NAME_COLOR, true);
+            y += textRenderer.fontHeight + LINE_GAP;
+        }
+
+        // Best time (singleplayer only)
+        if (singleplayer) {
+            long bestTimeMs = ResultStore.getBestTime(targetId);
+            if (bestTimeMs >= 0) {
+                String bestStr = "Best: " + HuntState.formatTime(bestTimeMs);
+                float bestWidthF = textRenderer.getWidth(bestStr) * BEST_SCALE;
+                context.getMatrices().pushMatrix();
+                context.getMatrices().translate(centreX - bestWidthF / 2f, (float) y);
+                context.getMatrices().scale(BEST_SCALE, BEST_SCALE);
+                context.drawText(textRenderer, bestStr, 0, 0, BEST_COLOR, true);
+                context.getMatrices().popMatrix();
+            }
         }
     }
 }

--- a/src/main/java/com/spawnhunt/network/ClientHuntState.java
+++ b/src/main/java/com/spawnhunt/network/ClientHuntState.java
@@ -16,7 +16,8 @@ public class ClientHuntState {
 
     public static void update(HuntSyncS2CPayload payload) {
         active = payload.active();
-        targetItem = payload.active() ? Identifier.of(payload.targetItemId()) : null;
+        targetItem = (payload.active() && !payload.targetItemId().isEmpty())
+                ? Identifier.of(payload.targetItemId()) : null;
         elapsedMs = payload.elapsedMs();
         won = payload.won();
         winnerName = payload.winnerName();

--- a/src/main/java/com/spawnhunt/network/ClientHuntState.java
+++ b/src/main/java/com/spawnhunt/network/ClientHuntState.java
@@ -1,0 +1,48 @@
+package com.spawnhunt.network;
+
+import net.minecraft.util.Identifier;
+
+/**
+ * Client-side mirror of the server's hunt state, updated via network packets.
+ * Used by the HUD renderer when playing on a multiplayer server with SpawnHunt.
+ */
+public class ClientHuntState {
+    private static boolean active = false;
+    private static Identifier targetItem = null;
+    private static long elapsedMs = 0;
+    private static boolean won = false;
+    private static String winnerName = "";
+    private static long finalTimeMs = 0;
+
+    public static void update(HuntSyncS2CPayload payload) {
+        active = payload.active();
+        targetItem = payload.active() ? Identifier.of(payload.targetItemId()) : null;
+        elapsedMs = payload.elapsedMs();
+        won = payload.won();
+        winnerName = payload.winnerName();
+        finalTimeMs = payload.finalTimeMs();
+    }
+
+    public static void handleWin(HuntWinS2CPayload payload) {
+        won = true;
+        winnerName = payload.winnerName();
+        finalTimeMs = payload.finalTimeMs();
+        targetItem = Identifier.of(payload.targetItemId());
+    }
+
+    public static void reset() {
+        active = false;
+        targetItem = null;
+        elapsedMs = 0;
+        won = false;
+        winnerName = "";
+        finalTimeMs = 0;
+    }
+
+    public static boolean isActive() { return active; }
+    public static Identifier getTargetItem() { return targetItem; }
+    public static long getElapsedMs() { return elapsedMs; }
+    public static boolean isWon() { return won; }
+    public static String getWinnerName() { return winnerName; }
+    public static long getFinalTimeMs() { return finalTimeMs; }
+}

--- a/src/main/java/com/spawnhunt/network/HuntSyncS2CPayload.java
+++ b/src/main/java/com/spawnhunt/network/HuntSyncS2CPayload.java
@@ -22,10 +22,10 @@ public record HuntSyncS2CPayload(
         public HuntSyncS2CPayload decode(RegistryByteBuf buf) {
             return new HuntSyncS2CPayload(
                     buf.readBoolean(),
-                    buf.readString(),
+                    buf.readString(256),
                     buf.readLong(),
                     buf.readBoolean(),
-                    buf.readString(),
+                    buf.readString(64),
                     buf.readLong()
             );
         }

--- a/src/main/java/com/spawnhunt/network/HuntSyncS2CPayload.java
+++ b/src/main/java/com/spawnhunt/network/HuntSyncS2CPayload.java
@@ -1,0 +1,48 @@
+package com.spawnhunt.network;
+
+import net.minecraft.network.RegistryByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.packet.CustomPayload;
+import net.minecraft.util.Identifier;
+
+public record HuntSyncS2CPayload(
+        boolean active,
+        String targetItemId,
+        long elapsedMs,
+        boolean won,
+        String winnerName,
+        long finalTimeMs
+) implements CustomPayload {
+
+    public static final Id<HuntSyncS2CPayload> ID =
+            new Id<>(Identifier.of("spawnhunt", "hunt_sync"));
+
+    public static final PacketCodec<RegistryByteBuf, HuntSyncS2CPayload> CODEC = new PacketCodec<>() {
+        @Override
+        public HuntSyncS2CPayload decode(RegistryByteBuf buf) {
+            return new HuntSyncS2CPayload(
+                    buf.readBoolean(),
+                    buf.readString(),
+                    buf.readLong(),
+                    buf.readBoolean(),
+                    buf.readString(),
+                    buf.readLong()
+            );
+        }
+
+        @Override
+        public void encode(RegistryByteBuf buf, HuntSyncS2CPayload payload) {
+            buf.writeBoolean(payload.active);
+            buf.writeString(payload.targetItemId);
+            buf.writeLong(payload.elapsedMs);
+            buf.writeBoolean(payload.won);
+            buf.writeString(payload.winnerName);
+            buf.writeLong(payload.finalTimeMs);
+        }
+    };
+
+    @Override
+    public Id<? extends CustomPayload> getId() {
+        return ID;
+    }
+}

--- a/src/main/java/com/spawnhunt/network/HuntWinS2CPayload.java
+++ b/src/main/java/com/spawnhunt/network/HuntWinS2CPayload.java
@@ -1,0 +1,39 @@
+package com.spawnhunt.network;
+
+import net.minecraft.network.RegistryByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.packet.CustomPayload;
+import net.minecraft.util.Identifier;
+
+public record HuntWinS2CPayload(
+        String winnerName,
+        long finalTimeMs,
+        String targetItemId
+) implements CustomPayload {
+
+    public static final Id<HuntWinS2CPayload> ID =
+            new Id<>(Identifier.of("spawnhunt", "hunt_win"));
+
+    public static final PacketCodec<RegistryByteBuf, HuntWinS2CPayload> CODEC = new PacketCodec<>() {
+        @Override
+        public HuntWinS2CPayload decode(RegistryByteBuf buf) {
+            return new HuntWinS2CPayload(
+                    buf.readString(),
+                    buf.readLong(),
+                    buf.readString()
+            );
+        }
+
+        @Override
+        public void encode(RegistryByteBuf buf, HuntWinS2CPayload payload) {
+            buf.writeString(payload.winnerName);
+            buf.writeLong(payload.finalTimeMs);
+            buf.writeString(payload.targetItemId);
+        }
+    };
+
+    @Override
+    public Id<? extends CustomPayload> getId() {
+        return ID;
+    }
+}

--- a/src/main/java/com/spawnhunt/network/HuntWinS2CPayload.java
+++ b/src/main/java/com/spawnhunt/network/HuntWinS2CPayload.java
@@ -18,9 +18,9 @@ public record HuntWinS2CPayload(
         @Override
         public HuntWinS2CPayload decode(RegistryByteBuf buf) {
             return new HuntWinS2CPayload(
-                    buf.readString(),
+                    buf.readString(64),
                     buf.readLong(),
-                    buf.readString()
+                    buf.readString(256)
             );
         }
 

--- a/src/main/java/com/spawnhunt/network/SpawnHuntPayloads.java
+++ b/src/main/java/com/spawnhunt/network/SpawnHuntPayloads.java
@@ -1,0 +1,11 @@
+package com.spawnhunt.network;
+
+import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
+
+public class SpawnHuntPayloads {
+
+    public static void register() {
+        PayloadTypeRegistry.playS2C().register(HuntSyncS2CPayload.ID, HuntSyncS2CPayload.CODEC);
+        PayloadTypeRegistry.playS2C().register(HuntWinS2CPayload.ID, HuntWinS2CPayload.CODEC);
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -7,8 +7,11 @@
   "authors": [],
   "contact": {},
   "license": "MIT",
-  "environment": "client",
+  "environment": "*",
   "entrypoints": {
+    "main": [
+      "com.spawnhunt.SpawnHuntCommon"
+    ],
     "client": [
       "com.spawnhunt.SpawnHuntMod"
     ]


### PR DESCRIPTION
### Added

- Multiplayer support — server-authoritative hunts managed via /spawnhunt commands (start, stop, restart, status)
- Server-to-client HUD sync — mod clients see the full SpawnHunt HUD (target item, timer) during multiplayer hunts
- Vanilla client compatibility — players without the mod receive target and timer updates via the action bar, plus chat messages for start/stop/win events
- Server-side win detection — inventory scanning and victory announcements are handled by the server

### Improved

- HUD rendering — updated to support both singleplayer and multiplayer state sources seamlessly
- Hunt state cleanup — state resets properly on disconnect for both singleplayer and multiplayer sessions