### PR TITLE
Release/2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v2.1.0
+
+This release prevents players from circumventing the hunt by switching game modes during an active singleplayer session.
+
+### Fixed
+
+- Game mode is now locked to Survival during active singleplayer hunts, preventing players from opening to LAN with cheats to switch to Creative mode
+
 ## v2.0.0
 
 SpawnHunt now supports multiplayer — run hunts on any Fabric server with full HUD sync for mod clients and action bar fallback for vanilla players.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,7 @@ Uses [SemVer](https://semver.org/). Version is set in `gradle.properties` (`mod_
 
 | Version | Date       | Notes                                    |
 |---------|------------|------------------------------------------|
+| 2.1.0 | 2026-03-17 |  |
 | 2.0.0 | 2026-03-16 |  |
 | 2.0.0 | 2026-03-16 |  |
 | 2.0.0 | 2026-03-16 | Multiplayer support: server commands, HUD sync, vanilla client action bar |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,9 +142,7 @@ Uses [SemVer](https://semver.org/). Version is set in `gradle.properties` (`mod_
 
 | Version | Date       | Notes                                    |
 |---------|------------|------------------------------------------|
-| 2.1.0 | 2026-03-17 |  |
-| 2.0.0 | 2026-03-16 |  |
-| 2.0.0 | 2026-03-16 |  |
+| 2.1.0 | 2026-03-17 | Lock to survival during active singleplayer hunts |
 | 2.0.0 | 2026-03-16 | Multiplayer support: server commands, HUD sync, vanilla client action bar |
 | 1.3.0 | 2026-03-15 | HUD redesign, vertical menu layout, music disc naming, item pool fixes |
 | 1.2.0   | 2026-03-12 | Music disc song names, display name caching |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,7 @@ Uses [SemVer](https://semver.org/). Version is set in `gradle.properties` (`mod_
 
 | Version | Date       | Notes                                    |
 |---------|------------|------------------------------------------|
+| 2.1.0 | 2026-03-17 |  |
 | 2.1.0 | 2026-03-17 | Lock to survival during active singleplayer hunts |
 | 2.0.0 | 2026-03-16 | Multiplayer support: server commands, HUD sync, vanilla client action bar |
 | 1.3.0 | 2026-03-15 | HUD redesign, vertical menu layout, music disc naming, item pool fixes |

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.21.11+build.4
 loader_version=0.18.4
 
 # Mod Properties
-mod_version=2.0.0
+mod_version=2.1.0
 maven_group=com.spawnhunt
 archives_base_name=spawnhunt
 

--- a/src/main/java/com/spawnhunt/mixin/GameModeLockMixin.java
+++ b/src/main/java/com/spawnhunt/mixin/GameModeLockMixin.java
@@ -1,0 +1,40 @@
+package com.spawnhunt.mixin;
+
+import com.spawnhunt.data.HuntState;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import net.minecraft.world.GameMode;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ServerPlayerEntity.class)
+public abstract class GameModeLockMixin {
+
+    @Inject(method = "changeGameMode", at = @At("HEAD"), cancellable = true)
+    private void spawnhunt$blockGameModeChange(GameMode gameMode, CallbackInfoReturnable<Boolean> cir) {
+        ServerPlayerEntity self = (ServerPlayerEntity) (Object) this;
+
+        // Only lock on integrated server (singleplayer / open-to-LAN)
+        if (self.getEntityWorld().getServer().isDedicated()) return;
+
+        // Only lock during active, unwon hunts
+        if (!HuntState.isActive() || HuntState.isWon()) return;
+
+        // Allow staying in survival
+        if (gameMode == GameMode.SURVIVAL) return;
+
+        // Allow spectator when dead (hardcore death → "Spectate World")
+        if (gameMode == GameMode.SPECTATOR && self.isDead()) return;
+
+        // Block all other game mode changes
+        self.sendMessage(
+                Text.literal("[SpawnHunt] Game mode locked to Survival during active hunt.")
+                        .formatted(Formatting.RED),
+                false
+        );
+        cir.setReturnValue(false);
+    }
+}

--- a/src/main/resources/spawnhunt.mixins.json
+++ b/src/main/resources/spawnhunt.mixins.json
@@ -2,6 +2,9 @@
   "required": true,
   "package": "com.spawnhunt.mixin",
   "compatibilityLevel": "JAVA_21",
+  "mixins": [
+    "GameModeLockMixin"
+  ],
   "client": [
     "TitleScreenMixin",
     "CreateWorldScreenMixin"


### PR DESCRIPTION
 This release prevents players from circumventing the hunt by switching game modes during an active singleplayer session.

### Fixed

- Game mode is now locked to Survival during active singleplayer hunts, preventing players from opening to LAN with cheats to switch to Creative mode