### PR TITLE
Allow starting a new hunt after a win without needing to stop first

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -31,8 +31,10 @@ jobs:
         run: |
           DATE=$(date -u +%Y-%m-%d)
           VERSION="${{ steps.version.outputs.version }}"
-          # Insert new row after the table header separator line
-          sed -i "/^|---------|------------|/a | $VERSION | $DATE |  |" CLAUDE.md
+          # Only insert if a row for this version doesn't already exist
+          if ! grep -q "| $VERSION |" CLAUDE.md; then
+            sed -i "/^|---------|------------|/a | $VERSION | $DATE |  |" CLAUDE.md
+          fi
 
       - name: Commit version bump
         run: |

--- a/src/main/java/com/spawnhunt/command/SpawnHuntCommand.java
+++ b/src/main/java/com/spawnhunt/command/SpawnHuntCommand.java
@@ -56,17 +56,23 @@ public class SpawnHuntCommand {
     }
 
     private static int startRandom(CommandContext<ServerCommandSource> context) {
-        if (ServerHuntState.isActive()) {
+        if (ServerHuntState.isActive() && !ServerHuntState.isWon()) {
             context.getSource().sendError(Text.literal("A hunt is already active! Use /spawnhunt stop first."));
             return 0;
+        }
+        if (ServerHuntState.isActive()) {
+            doStop(context);
         }
         return doStart(context, ItemPool.getRandomItem(ThreadLocalRandom.current()));
     }
 
     private static int startSpecific(CommandContext<ServerCommandSource> context) {
-        if (ServerHuntState.isActive()) {
+        if (ServerHuntState.isActive() && !ServerHuntState.isWon()) {
             context.getSource().sendError(Text.literal("A hunt is already active! Use /spawnhunt stop first."));
             return 0;
+        }
+        if (ServerHuntState.isActive()) {
+            doStop(context);
         }
         Item item = resolveItem(context);
         if (item == null) return 0;


### PR DESCRIPTION
Previously, /spawnhunt start blocked with "A hunt is already active" even after a win. Now a won hunt no longer blocks starting a new game, matching the natural instinct to immediately start another round.