### PR TITLE
Release/2.2.1

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -31,8 +31,10 @@ jobs:
         run: |
           DATE=$(date -u +%Y-%m-%d)
           VERSION="${{ steps.version.outputs.version }}"
-          # Insert new row after the table header separator line
-          sed -i "/^|---------|------------|/a | $VERSION | $DATE |  |" CLAUDE.md
+          # Only insert if a row for this version doesn't already exist
+          if ! grep -q "| $VERSION |" CLAUDE.md; then
+            sed -i "/^|---------|------------|/a | $VERSION | $DATE |  |" CLAUDE.md
+          fi
 
       - name: Commit version bump
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,7 @@ Uses [SemVer](https://semver.org/). Version is set in `gradle.properties` (`mod_
 
 | Version | Date       | Notes                                    |
 |---------|------------|------------------------------------------|
+| 2.2.1 | 2026-03-23 |  |
 | 2.2.0 | 2026-03-22 |  |
 | 2.2.0 | 2026-03-22 | Slot machine rolling animation |
 | 2.1.0 | 2026-03-17 | Lock to survival during active singleplayer hunts |

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.21.11+build.4
 loader_version=0.18.4
 
 # Mod Properties
-mod_version=2.2.0
+mod_version=2.2.1
 maven_group=com.spawnhunt
 archives_base_name=spawnhunt
 

--- a/src/main/java/com/spawnhunt/command/SpawnHuntCommand.java
+++ b/src/main/java/com/spawnhunt/command/SpawnHuntCommand.java
@@ -56,17 +56,23 @@ public class SpawnHuntCommand {
     }
 
     private static int startRandom(CommandContext<ServerCommandSource> context) {
-        if (ServerHuntState.isActive()) {
+        if (ServerHuntState.isActive() && !ServerHuntState.isWon()) {
             context.getSource().sendError(Text.literal("A hunt is already active! Use /spawnhunt stop first."));
             return 0;
+        }
+        if (ServerHuntState.isActive()) {
+            doStop(context);
         }
         return doStart(context, ItemPool.getRandomItem(ThreadLocalRandom.current()));
     }
 
     private static int startSpecific(CommandContext<ServerCommandSource> context) {
-        if (ServerHuntState.isActive()) {
+        if (ServerHuntState.isActive() && !ServerHuntState.isWon()) {
             context.getSource().sendError(Text.literal("A hunt is already active! Use /spawnhunt stop first."));
             return 0;
+        }
+        if (ServerHuntState.isActive()) {
+            doStop(context);
         }
         Item item = resolveItem(context);
         if (item == null) return 0;


### PR DESCRIPTION
Starting a new multiplayer hunt after a win no longer requires running /spawnhunt stop first - a completed hunt is automatically cleared when starting the next round