### PR TITLE
Port to Minecraft 26.1 (v3.0.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,15 +1,15 @@
 # SpawnHunt
 
-A Fabric mod for Minecraft Java Edition 1.21.11.
+A Fabric mod for Minecraft Java Edition 26.1.
 Speedrun-style scavenger hunt: find and collect a random survival-obtainable block as fast as possible.
 Supports both singleplayer (client-side) and multiplayer (server-side commands + HUD sync).
 
 ## Testing Environment
 
-- **Minecraft instance (macOS):** `/Applications/MultiMC.app/Data/instances/SpawnHunt/.minecraft`
-- **Minecraft instance (Windows):** `C:\MultiMC\instances\SpawnHunt\.minecraft`
+- **Minecraft instance (macOS):** `/Applications/MultiMC.app/Data/instances/SpawnHunt 26.1/.minecraft`
+- **Minecraft instance (Windows):** `C:\MultiMC\instances\SpawnHunt 26.1\.minecraft`
 - Built `.jar` goes into the `mods/` folder of that instance
-- Requires Fabric Loader + Fabric API for MC 1.21.11
+- Requires Fabric Loader + Fabric API for MC 26.1
 
 ## Project Structure
 
@@ -45,16 +45,17 @@ com.spawnhunt
 
 ## Tech Stack
 
-- **Build:** Gradle 9.2.1 + Fabric Loom 1.15.4
-- **Java:** JDK 21 (Eclipse Adoptium 21.0.10+7) at `C:\Program Files\Eclipse Adoptium\jdk-21.0.10.7-hotspot`
-- **Dependencies:** fabric-loader 0.18.4, fabric-api 0.141.3+1.21.11, Yarn 1.21.11+build.4
+- **Build:** Gradle 9.4.0 + Fabric Loom 1.16.1 (`net.fabricmc.fabric-loom` — no-remap for unobfuscated MC)
+- **Java:** JDK 25 (Eclipse Adoptium 25.0.2+10) at `C:\Program Files\Eclipse Adoptium\jdk-25.0.2.10-hotspot`
+- **Dependencies:** fabric-loader 0.18.4, fabric-api 0.144.4+26.1
+- **Mappings:** None (MC 26.1 is unobfuscated — uses Mojang official names directly)
 - **Language:** Java
 
 ## Build Commands
 
 ```bash
-# Build (must use JDK 21)
-JAVA_HOME="/c/Program Files/Eclipse Adoptium/jdk-21.0.10.7-hotspot" ./gradlew build
+# Build (must use JDK 25)
+JAVA_HOME="/c/Program Files/Eclipse Adoptium/jdk-25.0.2.10-hotspot" ./gradlew build
 
 # Output jar: build/libs/spawnhunt-<version>.jar
 ```
@@ -89,7 +90,7 @@ JAVA_HOME="/c/Program Files/Eclipse Adoptium/jdk-21.0.10.7-hotspot" ./gradlew bu
 - [x] 5.3 Start timer on world load
 
 ### Phase 6 — In-Game HUD
-- [x] 6.1 Create `HuntHudRenderer` (HudRenderCallback)
+- [x] 6.1 Create `HuntHudRenderer` (HudElementRegistry)
 - [x] 6.2 Render timer (mm:ss.000 format, semi-transparent background)
 - [x] 6.3 Render target block (top-left, 16x16 icon + name + timer, bordered box)
 - [x] 6.4 Pause-aware timer logic (delta-accumulation, no drift)
@@ -142,6 +143,7 @@ Uses [SemVer](https://semver.org/). Version is set in `gradle.properties` (`mod_
 
 | Version | Date       | Notes                                    |
 |---------|------------|------------------------------------------|
+| 3.0.0 | 2026-04-16 | Port to MC 26.1: Java 25, Mojang mappings, HudElementRegistry, unobfuscated build |
 | 2.2.1 | 2026-03-23 |  |
 | 2.2.0 | 2026-03-22 |  |
 | 2.2.0 | 2026-03-22 | Slot machine rolling animation |
@@ -152,7 +154,26 @@ Uses [SemVer](https://semver.org/). Version is set in `gradle.properties` (`mod_
 | 1.1.0   | 2026-02-26 | UI polish, win state rework, world naming   |
 | 1.0.0   | 2026-02-26 | Initial public release on Modrinth          |
 
+## API Notes (MC 26.1)
+
+- MC 26.1 is **unobfuscated** — uses Mojang official names, no Yarn/intermediary mappings
+- `GuiGraphicsExtractor` replaces old `DrawContext`/`GuiGraphics` — methods: `item()`, `text()`, `centeredText()`, `fill()`
+- Screen render method is `extractRenderState()`, list entry render is `extractContent()`
+- `HudRenderCallback` removed — use `HudElementRegistry.addLast(Identifier, HudElement)` instead
+- `HudElement` interface: `extractRenderState(GuiGraphicsExtractor, DeltaTracker)`
+- Matrix stack from `pose()` is JOML `Matrix3x2fStack` — uses `pushMatrix()`/`popMatrix()` (not pushPose/popPose)
+- `CustomPayload` → `CustomPacketPayload`, `Id<>` → `Type<>`, `getId()` → `type()`
+- `readString`/`writeString` → `readUtf`/`writeUtf` on FriendlyByteBuf
+- `PayloadTypeRegistry.playS2C()` → `.clientboundPlay()`
+- `Identifier` lives at `net.minecraft.resources.Identifier` (not `util` or `ResourceLocation`)
+- `Screen.client` field → `Screen.minecraft`
+- `player.sendMessage(text, true)` → `player.sendOverlayMessage(text)` (action bar)
+- `player.sendMessage(text, false)` → `player.sendSystemMessage(text)` (chat)
+- `EditBox.getText()` → `getValue()`, `setChangedListener()` → `setResponder()`
+- `ObjectSelectionList.getSelectedOrNull()` → `getSelected()`
+- `Checkbox.Builder.checked()` → `selected()`, `.callback()` → `.onValueChange()`
+
 ## Conventions
 
 - Keep mixin surface area minimal to reduce breakage on MC updates.
-- Pin to MC 1.21.11, use only stable Fabric API modules.
+- Target MC 26.1, use only stable Fabric API modules.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,8 @@ com.spawnhunt
 │   └── ServerHuntManager.java     // Server tick: inventory scan, timer broadcast, win detection
 └── mixin/
     ├── TitleScreenMixin.java      // Injects "SpawnHunt" button into main menu
-    └── CreateWorldScreenMixin.java // Auto-configures and triggers world creation
+    ├── CreateWorldScreenMixin.java // Auto-configures and triggers world creation
+    └── GameModeLockMixin.java     // Prevents game mode changes during active SP hunts
 ```
 
 ## Tech Stack
@@ -131,11 +132,14 @@ JAVA_HOME="/c/Program Files/Eclipse Adoptium/jdk-25.0.2.10-hotspot" ./gradlew bu
 - **Two separate state paths** — singleplayer uses `HuntState` (client static), multiplayer uses `ServerHuntState` (server) synced to `ClientHuntState` (client mirror). No shared mutable state.
 - **Vanilla client support** — players without the mod see action bar messages during active hunts and chat messages for start/stop/win events.
 - **Multiplayer commands** require OP level 2 (GAMEMASTERS); `/spawnhunt status` is available to all players.
+- **Pre-world item rendering** — MC 26.1 binds item components (including `ITEM_MODEL`) during world load, but the selection screen runs pre-world. `ItemPool.ensureComponentsBound()` binds a minimal `DataComponentMap` with `ITEM_MODEL` set to the item's registry ID so `ItemStack` creation and rendering works on the title screen. Vanilla overwrites with full data-driven components during world load.
+- **Display names** use `Component.translatable(item.getDescriptionId())` instead of `ItemStack.getHoverName()` to avoid creating ItemStacks for name resolution (safe pre-world).
 
 ## Key Risks
 
 - **Programmatic world creation** has no clean public API — may need deep mixins or auto-click approach as fallback.
 - **Item pool accuracy** — maintain exclusion list carefully, log pool on startup, iterate via community feedback.
+- **Pre-world component binding** — `ensureComponentsBound()` binds minimal components before vanilla does. If vanilla changes the binding lifecycle or adds validation, this could break. Monitor across MC updates.
 
 ## Versioning
 
@@ -145,7 +149,6 @@ Uses [SemVer](https://semver.org/). Version is set in `gradle.properties` (`mod_
 |---------|------------|------------------------------------------|
 | 3.0.0 | 2026-04-16 | Port to MC 26.1: Java 25, Mojang mappings, HudElementRegistry, unobfuscated build |
 | 2.2.1 | 2026-03-23 |  |
-| 2.2.0 | 2026-03-22 |  |
 | 2.2.0 | 2026-03-22 | Slot machine rolling animation |
 | 2.1.0 | 2026-03-17 | Lock to survival during active singleplayer hunts |
 | 2.0.0 | 2026-03-16 | Multiplayer support: server commands, HUD sync, vanilla client action bar |
@@ -172,6 +175,26 @@ Uses [SemVer](https://semver.org/). Version is set in `gradle.properties` (`mod_
 - `EditBox.getText()` → `getValue()`, `setChangedListener()` → `setResponder()`
 - `ObjectSelectionList.getSelectedOrNull()` → `getSelected()`
 - `Checkbox.Builder.checked()` → `selected()`, `.callback()` → `.onValueChange()`
+- `Button.dimensions()` → `bounds()`, `addDrawableChild()` → `addRenderableWidget()`
+- `Screen.close()` → `onClose()` override
+- `getWindow().getScaledWidth()` → `getWindow().getGuiScaledWidth()`
+- `source.sendError()` → `sendFailure()`, `sendFeedback()` → `sendSuccess()`
+- `Permission.Level` → `Permission.HasCommandLevel`, `source.getPermissions()` → `source.permissions()`
+- `isDead()` → `isDeadOrDying()`, `getEntityWorld()` → `level()`
+- `server.getPlayerManager().getPlayerList()` → `server.getPlayerList().getPlayers()`
+- `server.getCurrentPlayerCount()` → `server.getPlayerCount()`
+- `server.isDedicated()` → `server.isDedicatedServer()`
+- `CreateWorldScreen.show()` → `openFresh()`, `createLevel()` → `onCreate()`
+- `WorldCreator` → `WorldCreationUiState`, `getWorldCreator()` → `getUiState()`
+- `WorldCreator.Mode.HARDCORE` → `WorldCreationUiState.SelectedGameMode.HARDCORE`
+- `setCheatsEnabled()` → `setAllowCommands()`, `setWorldName()`/`getWorldName()` → `setName()`/`getName()`
+- `MinecraftClient.send()` → `Minecraft.execute()`
+- `IdentifierArgumentType.identifier()` → `IdentifierArgument.id()`, `.getIdentifier()` → `.getId()`
+- `Registries.ITEM` → `BuiltInRegistries.ITEM`, `.getId()` → `.getKey()`, `.containsId()` → `.containsKey()`
+- `Registry.get(Identifier)` now returns `Optional<Reference<T>>` — use `DefaultedRegistry.getValue()` for direct lookup
+- `Item.components()` delegates to holder — crashes if components not bound; use `Item.getDescriptionId()` for safe pre-world name access
+- Access widener namespace must be `official` (not `named`) for unobfuscated MC
+- `DataComponents.ITEM_MODEL` (`Identifier`) drives item rendering — must be set for `context.item()` to render
 
 ## Conventions
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.15.4'
+    id 'net.fabricmc.fabric-loom' version '1.16.1'
     id 'java'
 }
 
@@ -19,9 +19,9 @@ repositories {
 dependencies {
     // To change the versions see the gradle.properties file
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
-    mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-    modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-    modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+    // No mappings needed — MC 26.1 is unobfuscated
+    implementation "net.fabricmc:fabric-loader:${project.loader_version}"
+    implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 }
 
 processResources {
@@ -33,12 +33,12 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-    it.options.release = 21
+    it.options.release = 25
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
 
     withSourcesJar()
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,14 +4,13 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # Check these at https://fabricmc.net/develop/
-minecraft_version=1.21.11
-yarn_mappings=1.21.11+build.4
+minecraft_version=26.1
 loader_version=0.18.4
 
 # Mod Properties
-mod_version=2.2.1
+mod_version=3.0.0
 maven_group=com.spawnhunt
 archives_base_name=spawnhunt
 
 # Dependencies
-fabric_version=0.141.3+1.21.11
+fabric_version=0.144.4+26.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,10 @@ pluginManagement {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'
         }
+        maven {
+            name = 'FabricLoom'
+            url = 'https://maven.fabricmc.net/net/fabricmc/fabric-loom/'
+        }
         gradlePluginPortal()
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,10 +4,6 @@ pluginManagement {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'
         }
-        maven {
-            name = 'FabricLoom'
-            url = 'https://maven.fabricmc.net/net/fabricmc/fabric-loom/'
-        }
         gradlePluginPortal()
     }
 }

--- a/src/main/java/com/spawnhunt/SpawnHuntMod.java
+++ b/src/main/java/com/spawnhunt/SpawnHuntMod.java
@@ -13,9 +13,10 @@ import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
-import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback;
-import net.minecraft.client.gui.screen.DeathScreen;
-import net.minecraft.sound.SoundEvents;
+import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElementRegistry;
+import net.minecraft.client.gui.screens.DeathScreen;
+import net.minecraft.resources.Identifier;
+import net.minecraft.sounds.SoundEvents;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +42,7 @@ public class SpawnHuntMod implements ClientModInitializer {
         // Tick the timer and check inventory each client tick
         ClientTickEvents.END_CLIENT_TICK.register(client -> {
             if (HuntState.isActive() && !HuntState.isWon() && client.player != null) {
-                boolean paused = client.isPaused() || client.currentScreen instanceof DeathScreen;
+                boolean paused = client.isPaused() || client.screen instanceof DeathScreen;
                 HuntState.tick(paused);
                 InventoryListener.tick(client);
             }
@@ -51,7 +52,7 @@ public class SpawnHuntMod implements ClientModInitializer {
         WorldLifecycleHandler.register();
 
         // Render the HUD overlay (target block + timer)
-        HudRenderCallback.EVENT.register(HuntHudRenderer::render);
+        HudElementRegistry.addLast(Identifier.fromNamespaceAndPath("spawnhunt", "hud"), HuntHudRenderer::extractRenderState);
 
         // Register multiplayer packet receivers
         ClientPlayNetworking.registerGlobalReceiver(HuntSyncS2CPayload.ID, (payload, context) -> {

--- a/src/main/java/com/spawnhunt/command/SpawnHuntCommand.java
+++ b/src/main/java/com/spawnhunt/command/SpawnHuntCommand.java
@@ -7,25 +7,25 @@ import com.spawnhunt.data.ItemPool;
 import com.spawnhunt.data.HuntState;
 import com.spawnhunt.data.ServerHuntState;
 import com.spawnhunt.event.ServerHuntManager;
-import net.minecraft.command.argument.IdentifierArgumentType;
-import net.minecraft.command.permission.Permission;
-import net.minecraft.command.permission.PermissionLevel;
-import net.minecraft.item.Item;
-import net.minecraft.registry.Registries;
-import net.minecraft.server.command.CommandManager;
-import net.minecraft.server.command.ServerCommandSource;
-import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
-import net.minecraft.util.Identifier;
+import net.minecraft.commands.arguments.IdentifierArgument;
+import net.minecraft.server.permissions.Permission;
+import net.minecraft.server.permissions.PermissionLevel;
+import net.minecraft.world.item.Item;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.network.chat.Component;
+import net.minecraft.ChatFormatting;
+import net.minecraft.resources.Identifier;
 
 import java.util.concurrent.ThreadLocalRandom;
 
 public class SpawnHuntCommand {
 
-    private static final SuggestionProvider<ServerCommandSource> ITEM_SUGGESTIONS = (context, builder) -> {
+    private static final SuggestionProvider<CommandSourceStack> ITEM_SUGGESTIONS = (context, builder) -> {
         String remaining = builder.getRemaining().toLowerCase();
         for (Item item : ItemPool.getPool()) {
-            String id = Registries.ITEM.getId(item).toString();
+            String id = BuiltInRegistries.ITEM.getKey(item).toString();
             if (id.startsWith(remaining) || id.startsWith("minecraft:" + remaining)) {
                 builder.suggest(id);
             }
@@ -33,31 +33,31 @@ public class SpawnHuntCommand {
         return builder.buildFuture();
     };
 
-    public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
-        dispatcher.register(CommandManager.literal("spawnhunt")
-                .then(CommandManager.literal("start")
-                        .requires(source -> source.getPermissions().hasPermission(new Permission.Level(PermissionLevel.GAMEMASTERS)))
-                        .then(CommandManager.literal("random")
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(Commands.literal("spawnhunt")
+                .then(Commands.literal("start")
+                        .requires(source -> source.permissions().hasPermission(new Permission.HasCommandLevel(PermissionLevel.GAMEMASTERS)))
+                        .then(Commands.literal("random")
                                 .executes(SpawnHuntCommand::startRandom))
-                        .then(CommandManager.argument("item", IdentifierArgumentType.identifier())
+                        .then(Commands.argument("item", IdentifierArgument.id())
                                 .suggests(ITEM_SUGGESTIONS)
                                 .executes(SpawnHuntCommand::startSpecific)))
-                .then(CommandManager.literal("stop")
-                        .requires(source -> source.getPermissions().hasPermission(new Permission.Level(PermissionLevel.GAMEMASTERS)))
+                .then(Commands.literal("stop")
+                        .requires(source -> source.permissions().hasPermission(new Permission.HasCommandLevel(PermissionLevel.GAMEMASTERS)))
                         .executes(SpawnHuntCommand::stop))
-                .then(CommandManager.literal("restart")
-                        .requires(source -> source.getPermissions().hasPermission(new Permission.Level(PermissionLevel.GAMEMASTERS)))
+                .then(Commands.literal("restart")
+                        .requires(source -> source.permissions().hasPermission(new Permission.HasCommandLevel(PermissionLevel.GAMEMASTERS)))
                         .executes(SpawnHuntCommand::restartRandom)
-                        .then(CommandManager.argument("item", IdentifierArgumentType.identifier())
+                        .then(Commands.argument("item", IdentifierArgument.id())
                                 .suggests(ITEM_SUGGESTIONS)
                                 .executes(SpawnHuntCommand::restartSpecific)))
-                .then(CommandManager.literal("status")
+                .then(Commands.literal("status")
                         .executes(SpawnHuntCommand::status)));
     }
 
-    private static int startRandom(CommandContext<ServerCommandSource> context) {
+    private static int startRandom(CommandContext<CommandSourceStack> context) {
         if (ServerHuntState.isActive() && !ServerHuntState.isWon()) {
-            context.getSource().sendError(Text.literal("A hunt is already active! Use /spawnhunt stop first."));
+            context.getSource().sendFailure(Component.literal("A hunt is already active! Use /spawnhunt stop first."));
             return 0;
         }
         if (ServerHuntState.isActive()) {
@@ -66,9 +66,9 @@ public class SpawnHuntCommand {
         return doStart(context, ItemPool.getRandomItem(ThreadLocalRandom.current()));
     }
 
-    private static int startSpecific(CommandContext<ServerCommandSource> context) {
+    private static int startSpecific(CommandContext<CommandSourceStack> context) {
         if (ServerHuntState.isActive() && !ServerHuntState.isWon()) {
-            context.getSource().sendError(Text.literal("A hunt is already active! Use /spawnhunt stop first."));
+            context.getSource().sendFailure(Component.literal("A hunt is already active! Use /spawnhunt stop first."));
             return 0;
         }
         if (ServerHuntState.isActive()) {
@@ -79,104 +79,104 @@ public class SpawnHuntCommand {
         return doStart(context, item);
     }
 
-    private static int stop(CommandContext<ServerCommandSource> context) {
+    private static int stop(CommandContext<CommandSourceStack> context) {
         if (!ServerHuntState.isActive()) {
-            context.getSource().sendError(Text.literal("No hunt is currently active."));
+            context.getSource().sendFailure(Component.literal("No hunt is currently active."));
             return 0;
         }
 
         doStop(context);
 
-        Text message = Text.empty()
-                .append(Text.literal("[SpawnHunt] ").formatted(Formatting.GOLD))
-                .append(Text.literal("Hunt stopped.").formatted(Formatting.RED));
+        Component message = Component.empty()
+                .append(Component.literal("[SpawnHunt] ").withStyle(ChatFormatting.GOLD))
+                .append(Component.literal("Hunt stopped.").withStyle(ChatFormatting.RED));
 
         ServerHuntManager.broadcastMessage(context.getSource().getServer(), message);
         return 1;
     }
 
-    private static int restartRandom(CommandContext<ServerCommandSource> context) {
+    private static int restartRandom(CommandContext<CommandSourceStack> context) {
         doStop(context);
         return doStart(context, ItemPool.getRandomItem(ThreadLocalRandom.current()));
     }
 
-    private static int restartSpecific(CommandContext<ServerCommandSource> context) {
+    private static int restartSpecific(CommandContext<CommandSourceStack> context) {
         Item item = resolveItem(context);
         if (item == null) return 0;
         doStop(context);
         return doStart(context, item);
     }
 
-    private static Item resolveItem(CommandContext<ServerCommandSource> context) {
-        Identifier itemId = IdentifierArgumentType.getIdentifier(context, "item");
+    private static Item resolveItem(CommandContext<CommandSourceStack> context) {
+        Identifier itemId = IdentifierArgument.getId(context, "item");
 
-        if (!Registries.ITEM.containsId(itemId)) {
-            context.getSource().sendError(Text.literal("Unknown item: " + itemId));
+        if (!BuiltInRegistries.ITEM.containsKey(itemId)) {
+            context.getSource().sendFailure(Component.literal("Unknown item: " + itemId));
             return null;
         }
 
-        Item item = Registries.ITEM.get(itemId);
+        Item item = BuiltInRegistries.ITEM.getValue(itemId);
 
         if (!ItemPool.getPool().contains(item)) {
-            context.getSource().sendError(Text.literal("Item not in the SpawnHunt pool: " + itemId));
+            context.getSource().sendFailure(Component.literal("Item not in the SpawnHunt pool: " + itemId));
             return null;
         }
 
         return item;
     }
 
-    private static int doStart(CommandContext<ServerCommandSource> context, Item item) {
-        Identifier itemId = Registries.ITEM.getId(item);
+    private static int doStart(CommandContext<CommandSourceStack> context, Item item) {
+        Identifier itemId = BuiltInRegistries.ITEM.getKey(item);
         ServerHuntState.start(itemId);
 
-        Text itemName = ItemPool.getDisplayName(item);
-        Text message = Text.empty()
-                .append(Text.literal("[SpawnHunt] ").formatted(Formatting.GOLD))
-                .append(Text.literal("Hunt started! Find: ").formatted(Formatting.YELLOW))
-                .append(Text.literal(itemName.getString()).formatted(Formatting.AQUA));
+        Component itemName = ItemPool.getDisplayName(item);
+        Component message = Component.empty()
+                .append(Component.literal("[SpawnHunt] ").withStyle(ChatFormatting.GOLD))
+                .append(Component.literal("Hunt started! Find: ").withStyle(ChatFormatting.YELLOW))
+                .append(Component.literal(itemName.getString()).withStyle(ChatFormatting.AQUA));
 
         ServerHuntManager.broadcastMessage(context.getSource().getServer(), message);
         return 1;
     }
 
-    private static void doStop(CommandContext<ServerCommandSource> context) {
+    private static void doStop(CommandContext<CommandSourceStack> context) {
         ServerHuntState.stop();
         ServerHuntManager.sendStopSync(context.getSource().getServer());
     }
 
-    private static int status(CommandContext<ServerCommandSource> context) {
+    private static int status(CommandContext<CommandSourceStack> context) {
         if (!ServerHuntState.isActive()) {
-            context.getSource().sendFeedback(() -> Text.literal("[SpawnHunt] No hunt active.").formatted(Formatting.GRAY), false);
+            context.getSource().sendSuccess(() -> Component.literal("[SpawnHunt] No hunt active.").withStyle(ChatFormatting.GRAY), false);
             return 1;
         }
 
         Identifier targetId = ServerHuntState.getTargetItem();
-        Item item = Registries.ITEM.get(targetId);
-        Text itemName = ItemPool.getDisplayName(item);
+        Item item = BuiltInRegistries.ITEM.getValue(targetId);
+        Component itemName = ItemPool.getDisplayName(item);
         String timeStr = HuntState.formatTimeSeconds(ServerHuntState.getElapsedMs());
-        int playerCount = context.getSource().getServer().getCurrentPlayerCount();
+        int playerCount = context.getSource().getServer().getPlayerCount();
 
-        Text status;
+        Component status;
         if (ServerHuntState.isWon()) {
-            status = Text.empty()
-                    .append(Text.literal("[SpawnHunt] ").formatted(Formatting.GOLD))
-                    .append(Text.literal(ServerHuntState.getWinnerName()).formatted(Formatting.GREEN))
-                    .append(Text.literal(" found ").formatted(Formatting.YELLOW))
-                    .append(Text.literal(itemName.getString()).formatted(Formatting.AQUA))
-                    .append(Text.literal(" in ").formatted(Formatting.YELLOW))
-                    .append(Text.literal(HuntState.formatTimeSeconds(ServerHuntState.getFinalTimeMs())).formatted(Formatting.WHITE));
+            status = Component.empty()
+                    .append(Component.literal("[SpawnHunt] ").withStyle(ChatFormatting.GOLD))
+                    .append(Component.literal(ServerHuntState.getWinnerName()).withStyle(ChatFormatting.GREEN))
+                    .append(Component.literal(" found ").withStyle(ChatFormatting.YELLOW))
+                    .append(Component.literal(itemName.getString()).withStyle(ChatFormatting.AQUA))
+                    .append(Component.literal(" in ").withStyle(ChatFormatting.YELLOW))
+                    .append(Component.literal(HuntState.formatTimeSeconds(ServerHuntState.getFinalTimeMs())).withStyle(ChatFormatting.WHITE));
         } else {
-            status = Text.empty()
-                    .append(Text.literal("[SpawnHunt] ").formatted(Formatting.GOLD))
-                    .append(Text.literal("Target: ").formatted(Formatting.YELLOW))
-                    .append(Text.literal(itemName.getString()).formatted(Formatting.AQUA))
-                    .append(Text.literal(" | Time: ").formatted(Formatting.YELLOW))
-                    .append(Text.literal(timeStr).formatted(Formatting.WHITE))
-                    .append(Text.literal(" | Players: ").formatted(Formatting.YELLOW))
-                    .append(Text.literal(String.valueOf(playerCount)).formatted(Formatting.WHITE));
+            status = Component.empty()
+                    .append(Component.literal("[SpawnHunt] ").withStyle(ChatFormatting.GOLD))
+                    .append(Component.literal("Target: ").withStyle(ChatFormatting.YELLOW))
+                    .append(Component.literal(itemName.getString()).withStyle(ChatFormatting.AQUA))
+                    .append(Component.literal(" | Time: ").withStyle(ChatFormatting.YELLOW))
+                    .append(Component.literal(timeStr).withStyle(ChatFormatting.WHITE))
+                    .append(Component.literal(" | Players: ").withStyle(ChatFormatting.YELLOW))
+                    .append(Component.literal(String.valueOf(playerCount)).withStyle(ChatFormatting.WHITE));
         }
 
-        context.getSource().sendFeedback(() -> status, false);
+        context.getSource().sendSuccess(() -> status, false);
         return 1;
     }
 }

--- a/src/main/java/com/spawnhunt/data/HuntState.java
+++ b/src/main/java/com/spawnhunt/data/HuntState.java
@@ -1,6 +1,6 @@
 package com.spawnhunt.data;
 
-import net.minecraft.util.Identifier;
+import net.minecraft.resources.Identifier;
 
 /**
  * Singleton holding all runtime state for the current hunt.

--- a/src/main/java/com/spawnhunt/data/ItemPool.java
+++ b/src/main/java/com/spawnhunt/data/ItemPool.java
@@ -58,10 +58,7 @@ public class ItemPool {
             "written_book",
             "firework_rocket",
             "firework_star",
-            "filled_map",
-
-            // Not fully available in 1.21.1
-            "bundle"
+            "filled_map"
     );
 
     private static boolean isExcluded(String path) {

--- a/src/main/java/com/spawnhunt/data/ItemPool.java
+++ b/src/main/java/com/spawnhunt/data/ItemPool.java
@@ -1,13 +1,14 @@
 package com.spawnhunt.data;
 
 import com.spawnhunt.SpawnHuntMod;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
-import net.minecraft.registry.Registries;
-import net.minecraft.util.Identifier;
+import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.Items;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.Identifier;
 
-import net.minecraft.text.Text;
+import net.minecraft.network.chat.Component;
 
 import java.util.*;
 
@@ -19,7 +20,7 @@ import java.util.*;
  */
 public class ItemPool {
     private static List<Item> pool = null;
-    private static final Map<Item, Text> displayNameCache = new HashMap<>();
+    private static final Map<Item, Component> displayNameCache = new HashMap<>();
 
     private static final Set<String> EXCLUDED = Set.of(
             // Creative-only / technical
@@ -80,10 +81,10 @@ public class ItemPool {
     private static List<Item> buildPool() {
         List<Item> result = new ArrayList<>();
 
-        for (Item item : Registries.ITEM) {
+        for (Item item : BuiltInRegistries.ITEM) {
             if (item == Items.AIR) continue;
 
-            Identifier id = Registries.ITEM.getId(item);
+            Identifier id = BuiltInRegistries.ITEM.getKey(item);
             if (!id.getNamespace().equals("minecraft")) continue;
 
             if (isExcluded(id.getPath())) continue;
@@ -94,6 +95,29 @@ public class ItemPool {
         return Collections.unmodifiableList(result);
     }
 
+    /**
+     * MC 26.1: item components are data-driven and not bound until world load.
+     * This binds a minimal component map (with ITEM_MODEL) so ItemStacks can be
+     * created pre-world for the selection screen. Vanilla overwrites with full
+     * data-driven components during world load.
+     */
+    public static void ensureComponentsBound() {
+        int bound = 0;
+        for (Item item : BuiltInRegistries.ITEM) {
+            if (!item.builtInRegistryHolder().areComponentsBound()) {
+                Identifier id = BuiltInRegistries.ITEM.getKey(item);
+                DataComponentMap components = DataComponentMap.builder()
+                        .set(DataComponents.ITEM_MODEL, id)
+                        .build();
+                item.builtInRegistryHolder().bindComponents(components);
+                bound++;
+            }
+        }
+        if (bound > 0) {
+            SpawnHuntMod.LOGGER.info("SpawnHunt: pre-bound model components for {} items (pre-world rendering)", bound);
+        }
+    }
+
     private static final String MUSIC_DISC_PREFIX = "music_disc_";
 
     /**
@@ -101,19 +125,20 @@ public class ItemPool {
      * "Music Disc - {song}" (e.g. "Music Disc - chirp") since getName()
      * alone just returns "Music Disc" for all of them.
      */
-    public static Text getDisplayName(Item item) {
-        Text cached = displayNameCache.get(item);
+    public static Component getDisplayName(Item item) {
+        Component cached = displayNameCache.get(item);
         if (cached != null) return cached;
 
-        ItemStack stack = new ItemStack(item);
-        Text name = stack.getName();
-
-        Identifier id = Registries.ITEM.getId(item);
+        Identifier id = BuiltInRegistries.ITEM.getKey(item);
         String path = id.getPath();
 
+        Component name;
         if (path.startsWith(MUSIC_DISC_PREFIX)) {
             String songId = path.substring(MUSIC_DISC_PREFIX.length());
-            name = Text.literal("Music Disc - " + songId);
+            name = Component.literal("Music Disc - " + songId);
+        } else {
+            // Use the translation key directly — safe pre-world (no ItemStack needed)
+            name = Component.translatable(item.getDescriptionId());
         }
 
         displayNameCache.put(item, name);
@@ -128,7 +153,7 @@ public class ItemPool {
     public static void logPool() {
         List<Item> p = getPool();
         for (Item item : p) {
-            SpawnHuntMod.LOGGER.debug("  pool: {}", Registries.ITEM.getId(item));
+            SpawnHuntMod.LOGGER.debug("  pool: {}", BuiltInRegistries.ITEM.getKey(item));
         }
         SpawnHuntMod.LOGGER.info("Item pool initialized — {} survival-obtainable items", p.size());
     }

--- a/src/main/java/com/spawnhunt/data/ResultStore.java
+++ b/src/main/java/com/spawnhunt/data/ResultStore.java
@@ -4,8 +4,8 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 import com.spawnhunt.SpawnHuntMod;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.util.Identifier;
+import net.minecraft.client.Minecraft;
+import net.minecraft.resources.Identifier;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -32,14 +32,14 @@ public class ResultStore {
     }
 
     private static String getUuid() {
-        var session = MinecraftClient.getInstance().getSession();
-        var uuid = session.getUuidOrNull();
+        var user = Minecraft.getInstance().getUser();
+        var uuid = user.getProfileId();
         return uuid != null ? uuid.toString() : "offline";
     }
 
     private static Path getFilePath() {
         String uuid = getUuid();
-        return MinecraftClient.getInstance().runDirectory.toPath()
+        return Minecraft.getInstance().gameDirectory.toPath()
                 .resolve("spawnhunt").resolve("results").resolve(uuid + ".json");
     }
 

--- a/src/main/java/com/spawnhunt/data/ServerHuntState.java
+++ b/src/main/java/com/spawnhunt/data/ServerHuntState.java
@@ -1,7 +1,7 @@
 package com.spawnhunt.data;
 
-import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.util.Identifier;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.level.ServerPlayer;
 
 import java.util.UUID;
 
@@ -29,11 +29,11 @@ public class ServerHuntState {
         reset();
     }
 
-    public static void win(ServerPlayerEntity player) {
+    public static void win(ServerPlayer player) {
         if (!active || won) return;
         finalTimeMs = System.currentTimeMillis() - startTimeMs;
         won = true;
-        winnerUuid = player.getUuid();
+        winnerUuid = player.getUUID();
         winnerName = player.getName().getString();
     }
 

--- a/src/main/java/com/spawnhunt/event/InventoryListener.java
+++ b/src/main/java/com/spawnhunt/event/InventoryListener.java
@@ -3,30 +3,30 @@ package com.spawnhunt.event;
 import com.spawnhunt.SpawnHuntMod;
 import com.spawnhunt.data.HuntState;
 import com.spawnhunt.data.ResultStore;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.network.ClientPlayerEntity;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.registry.Registries;
-import net.minecraft.sound.SoundEvents;
-import net.minecraft.util.Identifier;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.resources.Identifier;
 
 public class InventoryListener {
 
-    public static void tick(MinecraftClient client) {
+    public static void tick(Minecraft client) {
         if (!HuntState.isActive() || HuntState.isWon()) return;
 
-        ClientPlayerEntity player = client.player;
+        LocalPlayer player = client.player;
         if (player == null) return;
 
         Identifier targetId = HuntState.getTargetItem();
         if (targetId == null) return;
 
-        Item targetItem = Registries.ITEM.get(targetId);
+        Item targetItem = BuiltInRegistries.ITEM.getValue(targetId);
 
         // Scan main inventory (0-35), armor (36-39), and offhand (40)
-        for (int i = 0; i < player.getInventory().size(); i++) {
-            ItemStack stack = player.getInventory().getStack(i);
+        for (int i = 0; i < player.getInventory().getContainerSize(); i++) {
+            ItemStack stack = player.getInventory().getItem(i);
             if (!stack.isEmpty() && stack.getItem() == targetItem) {
                 HuntState.win();
                 ResultStore.recordResult(targetId, HuntState.getFinalTimeMs());

--- a/src/main/java/com/spawnhunt/event/ServerHuntManager.java
+++ b/src/main/java/com/spawnhunt/event/ServerHuntManager.java
@@ -8,15 +8,15 @@ import com.spawnhunt.network.HuntWinS2CPayload;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.registry.Registries;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.sound.SoundEvents;
-import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
-import net.minecraft.util.Identifier;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.network.chat.Component;
+import net.minecraft.ChatFormatting;
+import net.minecraft.resources.Identifier;
 
 public class ServerHuntManager {
 
@@ -27,7 +27,7 @@ public class ServerHuntManager {
 
         ServerPlayConnectionEvents.JOIN.register((handler, sender, server) -> {
             if (ServerHuntState.isActive()) {
-                ServerPlayerEntity player = handler.getPlayer();
+                ServerPlayer player = handler.getPlayer();
                 if (ServerPlayNetworking.canSend(player, HuntSyncS2CPayload.ID)) {
                     ServerPlayNetworking.send(player, buildSyncPayload());
                 }
@@ -63,11 +63,11 @@ public class ServerHuntManager {
         Identifier targetId = ServerHuntState.getTargetItem();
         if (targetId == null) return;
 
-        Item targetItem = Registries.ITEM.get(targetId);
+        Item targetItem = BuiltInRegistries.ITEM.getValue(targetId);
 
-        for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
-            for (int i = 0; i < player.getInventory().size(); i++) {
-                ItemStack stack = player.getInventory().getStack(i);
+        for (ServerPlayer player : server.getPlayerList().getPlayers()) {
+            for (int i = 0; i < player.getInventory().getContainerSize(); i++) {
+                ItemStack stack = player.getInventory().getItem(i);
                 if (!stack.isEmpty() && stack.getItem() == targetItem) {
                     handleWin(server, player);
                     return;
@@ -76,23 +76,23 @@ public class ServerHuntManager {
         }
     }
 
-    private static void handleWin(MinecraftServer server, ServerPlayerEntity winner) {
+    private static void handleWin(MinecraftServer server, ServerPlayer winner) {
         ServerHuntState.win(winner);
 
         Identifier targetId = ServerHuntState.getTargetItem();
-        Item item = Registries.ITEM.get(targetId);
-        Text itemName = ItemPool.getDisplayName(item);
+        Item item = BuiltInRegistries.ITEM.getValue(targetId);
+        Component itemName = ItemPool.getDisplayName(item);
         String timeStr = HuntState.formatTimeSeconds(ServerHuntState.getFinalTimeMs());
 
         // Chat message to all players
-        Text winMessage = Text.empty()
-                .append(Text.literal("[SpawnHunt] ").formatted(Formatting.GOLD))
-                .append(Text.literal(winner.getName().getString()).formatted(Formatting.GREEN))
-                .append(Text.literal(" found ").formatted(Formatting.YELLOW))
-                .append(Text.literal(itemName.getString()).formatted(Formatting.AQUA))
-                .append(Text.literal(" in ").formatted(Formatting.YELLOW))
-                .append(Text.literal(timeStr).formatted(Formatting.GREEN))
-                .append(Text.literal("!").formatted(Formatting.YELLOW));
+        Component winMessage = Component.empty()
+                .append(Component.literal("[SpawnHunt] ").withStyle(ChatFormatting.GOLD))
+                .append(Component.literal(winner.getName().getString()).withStyle(ChatFormatting.GREEN))
+                .append(Component.literal(" found ").withStyle(ChatFormatting.YELLOW))
+                .append(Component.literal(itemName.getString()).withStyle(ChatFormatting.AQUA))
+                .append(Component.literal(" in ").withStyle(ChatFormatting.YELLOW))
+                .append(Component.literal(timeStr).withStyle(ChatFormatting.GREEN))
+                .append(Component.literal("!").withStyle(ChatFormatting.YELLOW));
 
         broadcastMessage(server, winMessage);
 
@@ -103,7 +103,7 @@ public class ServerHuntManager {
                 targetId.toString()
         );
 
-        for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+        for (ServerPlayer player : server.getPlayerList().getPlayers()) {
             if (ServerPlayNetworking.canSend(player, HuntWinS2CPayload.ID)) {
                 ServerPlayNetworking.send(player, winPayload);
             } else {
@@ -117,7 +117,7 @@ public class ServerHuntManager {
 
     private static void broadcastSyncToModClients(MinecraftServer server) {
         HuntSyncS2CPayload payload = buildSyncPayload();
-        for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+        for (ServerPlayer player : server.getPlayerList().getPlayers()) {
             if (ServerPlayNetworking.canSend(player, HuntSyncS2CPayload.ID)) {
                 ServerPlayNetworking.send(player, payload);
             }
@@ -130,20 +130,20 @@ public class ServerHuntManager {
         Identifier targetId = ServerHuntState.getTargetItem();
         if (targetId == null) return;
 
-        Item item = Registries.ITEM.get(targetId);
-        Text itemName = ItemPool.getDisplayName(item);
+        Item item = BuiltInRegistries.ITEM.getValue(targetId);
+        Component itemName = ItemPool.getDisplayName(item);
         String timeStr = HuntState.formatTimeSeconds(ServerHuntState.getElapsedMs());
 
-        Text actionBar = Text.empty()
-                .append(Text.literal("SpawnHunt").formatted(Formatting.GOLD))
-                .append(Text.literal(" | ").formatted(Formatting.GRAY))
-                .append(Text.literal(itemName.getString()).formatted(Formatting.AQUA))
-                .append(Text.literal(" | ").formatted(Formatting.GRAY))
-                .append(Text.literal(timeStr).formatted(Formatting.WHITE));
+        Component actionBar = Component.empty()
+                .append(Component.literal("SpawnHunt").withStyle(ChatFormatting.GOLD))
+                .append(Component.literal(" | ").withStyle(ChatFormatting.GRAY))
+                .append(Component.literal(itemName.getString()).withStyle(ChatFormatting.AQUA))
+                .append(Component.literal(" | ").withStyle(ChatFormatting.GRAY))
+                .append(Component.literal(timeStr).withStyle(ChatFormatting.WHITE));
 
-        for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+        for (ServerPlayer player : server.getPlayerList().getPlayers()) {
             if (!ServerPlayNetworking.canSend(player, HuntSyncS2CPayload.ID)) {
-                player.sendMessage(actionBar, true);
+                player.sendOverlayMessage(actionBar);
             }
         }
     }
@@ -164,7 +164,7 @@ public class ServerHuntManager {
      */
     public static void sendStopSync(MinecraftServer server) {
         HuntSyncS2CPayload payload = new HuntSyncS2CPayload(false, "", 0, false, "", 0);
-        for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+        for (ServerPlayer player : server.getPlayerList().getPlayers()) {
             if (ServerPlayNetworking.canSend(player, HuntSyncS2CPayload.ID)) {
                 ServerPlayNetworking.send(player, payload);
             }
@@ -174,9 +174,9 @@ public class ServerHuntManager {
     /**
      * Sends a chat message to all players on the server.
      */
-    public static void broadcastMessage(MinecraftServer server, Text message) {
-        for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
-            player.sendMessage(message, false);
+    public static void broadcastMessage(MinecraftServer server, Component message) {
+        for (ServerPlayer player : server.getPlayerList().getPlayers()) {
+            player.sendSystemMessage(message);
         }
     }
 }

--- a/src/main/java/com/spawnhunt/hud/HuntHudRenderer.java
+++ b/src/main/java/com/spawnhunt/hud/HuntHudRenderer.java
@@ -3,16 +3,16 @@ package com.spawnhunt.hud;
 import com.spawnhunt.data.HuntState;
 import com.spawnhunt.data.ResultStore;
 import com.spawnhunt.network.ClientHuntState;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.render.RenderTickCounter;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.DeltaTracker;
 import com.spawnhunt.data.ItemPool;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.registry.Registries;
-import net.minecraft.text.Text;
-import net.minecraft.util.Identifier;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
 
 public class HuntHudRenderer {
 
@@ -23,13 +23,13 @@ public class HuntHudRenderer {
     private static final int BEST_COLOR = 0xFFAAFFAA;
     private static final int WIN_NAME_COLOR = 0xFF55FF55;
 
-    public static void render(DrawContext context, RenderTickCounter tickCounter) {
-        MinecraftClient client = MinecraftClient.getInstance();
+    public static void extractRenderState(GuiGraphicsExtractor context, DeltaTracker deltaTracker) {
+        Minecraft client = Minecraft.getInstance();
         if (client.player == null) return;
 
         // Multiplayer (server-authoritative) takes priority
         if (ClientHuntState.isActive()) {
-            renderHud(context, client.textRenderer,
+            renderHud(context, client.font,
                     ClientHuntState.getTargetItem(),
                     ClientHuntState.isWon(),
                     ClientHuntState.isWon() ? ClientHuntState.getFinalTimeMs() : ClientHuntState.getElapsedMs(),
@@ -40,7 +40,7 @@ public class HuntHudRenderer {
 
         // Singleplayer fallback
         if (HuntState.isActive()) {
-            renderHud(context, client.textRenderer,
+            renderHud(context, client.font,
                     HuntState.getTargetItem(),
                     HuntState.isWon(),
                     HuntState.isWon() ? HuntState.getFinalTimeMs() : HuntState.getAccumulatedMs(),
@@ -49,52 +49,52 @@ public class HuntHudRenderer {
         }
     }
 
-    private static void renderHud(DrawContext context, TextRenderer textRenderer,
+    private static void renderHud(GuiGraphicsExtractor context, Font font,
                                    Identifier targetId, boolean won, long timeMs,
                                    String winnerName, boolean singleplayer) {
         if (targetId == null) return;
 
-        Item item = Registries.ITEM.get(targetId);
+        Item item = BuiltInRegistries.ITEM.getValue(targetId);
         ItemStack stack = new ItemStack(item);
-        Text itemName = ItemPool.getDisplayName(item);
+        Component itemName = ItemPool.getDisplayName(item);
 
-        int screenWidth = MinecraftClient.getInstance().getWindow().getScaledWidth();
+        int screenWidth = Minecraft.getInstance().getWindow().getGuiScaledWidth();
         int centreX = screenWidth / 2;
         int y = TOP_MARGIN;
 
         // Item icon — centred at top
-        context.drawItem(stack, centreX - 8, y);
+        context.item(stack, centreX - 8, y);
         y += 16 + LINE_GAP;
 
         // Item name — centred below icon
-        int nameWidth = textRenderer.getWidth(itemName);
-        context.drawText(textRenderer, itemName,
+        int nameWidth = font.width(itemName);
+        context.text(font, itemName,
                 centreX - nameWidth / 2, y, won ? WIN_NAME_COLOR : 0xFFFFFFFF, true);
-        y += textRenderer.fontHeight + LINE_GAP;
+        y += font.lineHeight + LINE_GAP;
 
         // Timer — centred below name, larger on win
         String timeStr = singleplayer ? HuntState.formatTime(timeMs) : HuntState.formatTimeSeconds(timeMs);
         if (won) {
-            float timerWidthF = textRenderer.getWidth(timeStr) * WIN_TIMER_SCALE;
-            context.getMatrices().pushMatrix();
-            context.getMatrices().translate(centreX - timerWidthF / 2f, (float) y);
-            context.getMatrices().scale(WIN_TIMER_SCALE, WIN_TIMER_SCALE);
-            context.drawText(textRenderer, timeStr, 0, 0, 0xFFFFFFFF, true);
-            context.getMatrices().popMatrix();
-            y += (int) (textRenderer.fontHeight * WIN_TIMER_SCALE) + LINE_GAP;
+            float timerWidthF = font.width(timeStr) * WIN_TIMER_SCALE;
+            context.pose().pushMatrix();
+            context.pose().translate(centreX - timerWidthF / 2f, (float) y);
+            context.pose().scale(WIN_TIMER_SCALE, WIN_TIMER_SCALE);
+            context.text(font, timeStr, 0, 0, 0xFFFFFFFF, true);
+            context.pose().popMatrix();
+            y += (int) (font.lineHeight * WIN_TIMER_SCALE) + LINE_GAP;
         } else {
-            int timerWidth = textRenderer.getWidth(timeStr);
-            context.drawText(textRenderer, timeStr, centreX - timerWidth / 2, y, 0xFFFFFFFF, true);
-            y += textRenderer.fontHeight + LINE_GAP;
+            int timerWidth = font.width(timeStr);
+            context.text(font, timeStr, centreX - timerWidth / 2, y, 0xFFFFFFFF, true);
+            y += font.lineHeight + LINE_GAP;
         }
 
         // Winner name (multiplayer only)
         if (won && winnerName != null && !winnerName.isEmpty()) {
             String winText = winnerName + " wins!";
-            int winWidth = textRenderer.getWidth(winText);
-            context.drawText(textRenderer, winText,
+            int winWidth = font.width(winText);
+            context.text(font, winText,
                     centreX - winWidth / 2, y, WIN_NAME_COLOR, true);
-            y += textRenderer.fontHeight + LINE_GAP;
+            y += font.lineHeight + LINE_GAP;
         }
 
         // Best time (singleplayer only)
@@ -102,12 +102,12 @@ public class HuntHudRenderer {
             long bestTimeMs = ResultStore.getBestTime(targetId);
             if (bestTimeMs >= 0) {
                 String bestStr = "Best: " + HuntState.formatTime(bestTimeMs);
-                float bestWidthF = textRenderer.getWidth(bestStr) * BEST_SCALE;
-                context.getMatrices().pushMatrix();
-                context.getMatrices().translate(centreX - bestWidthF / 2f, (float) y);
-                context.getMatrices().scale(BEST_SCALE, BEST_SCALE);
-                context.drawText(textRenderer, bestStr, 0, 0, BEST_COLOR, true);
-                context.getMatrices().popMatrix();
+                float bestWidthF = font.width(bestStr) * BEST_SCALE;
+                context.pose().pushMatrix();
+                context.pose().translate(centreX - bestWidthF / 2f, (float) y);
+                context.pose().scale(BEST_SCALE, BEST_SCALE);
+                context.text(font, bestStr, 0, 0, BEST_COLOR, true);
+                context.pose().popMatrix();
             }
         }
     }

--- a/src/main/java/com/spawnhunt/hud/HuntHudRenderer.java
+++ b/src/main/java/com/spawnhunt/hud/HuntHudRenderer.java
@@ -23,6 +23,10 @@ public class HuntHudRenderer {
     private static final int BEST_COLOR = 0xFFAAFFAA;
     private static final int WIN_NAME_COLOR = 0xFF55FF55;
 
+    // Cached ItemStack — only recreated when targetId changes
+    private static Identifier cachedTargetId = null;
+    private static ItemStack cachedStack = null;
+
     public static void extractRenderState(GuiGraphicsExtractor context, DeltaTracker deltaTracker) {
         Minecraft client = Minecraft.getInstance();
         if (client.player == null) return;
@@ -54,16 +58,18 @@ public class HuntHudRenderer {
                                    String winnerName, boolean singleplayer) {
         if (targetId == null) return;
 
-        Item item = BuiltInRegistries.ITEM.getValue(targetId);
-        ItemStack stack = new ItemStack(item);
-        Component itemName = ItemPool.getDisplayName(item);
+        if (!targetId.equals(cachedTargetId)) {
+            cachedTargetId = targetId;
+            cachedStack = new ItemStack(BuiltInRegistries.ITEM.getValue(targetId));
+        }
+        Component itemName = ItemPool.getDisplayName(BuiltInRegistries.ITEM.getValue(targetId));
 
         int screenWidth = Minecraft.getInstance().getWindow().getGuiScaledWidth();
         int centreX = screenWidth / 2;
         int y = TOP_MARGIN;
 
         // Item icon — centred at top
-        context.item(stack, centreX - 8, y);
+        context.item(cachedStack, centreX - 8, y);
         y += 16 + LINE_GAP;
 
         // Item name — centred below icon

--- a/src/main/java/com/spawnhunt/mixin/CreateWorldScreenMixin.java
+++ b/src/main/java/com/spawnhunt/mixin/CreateWorldScreenMixin.java
@@ -3,12 +3,12 @@ package com.spawnhunt.mixin;
 import com.spawnhunt.SpawnHuntMod;
 import com.spawnhunt.data.HuntState;
 import com.spawnhunt.data.ItemPool;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.world.CreateWorldScreen;
-import net.minecraft.client.gui.screen.world.WorldCreator;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.registry.Registries;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.worldselection.CreateWorldScreen;
+import net.minecraft.client.gui.screens.worldselection.WorldCreationUiState;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.Difficulty;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -20,32 +20,32 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class CreateWorldScreenMixin {
 
     @Shadow
-    public abstract WorldCreator getWorldCreator();
+    public abstract WorldCreationUiState getUiState();
 
     @Shadow
-    abstract void createLevel();
+    abstract void onCreate();
 
     @Inject(method = "init", at = @At("TAIL"))
     private void spawnhunt$autoConfigureAndCreate(CallbackInfo ci) {
         if (!HuntState.isActive()) return;
 
-        WorldCreator creator = this.getWorldCreator();
+        WorldCreationUiState uiState = this.getUiState();
 
-        Item targetItem = Registries.ITEM.get(HuntState.getTargetItem());
+        Item targetItem = BuiltInRegistries.ITEM.getValue(HuntState.getTargetItem());
         String itemName = ItemPool.getDisplayName(targetItem).getString();
-        creator.setWorldName("SpawnHunt - " + itemName);
+        uiState.setName("SpawnHunt - " + itemName);
         if (HuntState.isHardcore()) {
-            creator.setGameMode(WorldCreator.Mode.HARDCORE);
-            creator.setDifficulty(Difficulty.HARD);
+            uiState.setGameMode(WorldCreationUiState.SelectedGameMode.HARDCORE);
+            uiState.setDifficulty(Difficulty.HARD);
         } else {
-            creator.setGameMode(WorldCreator.Mode.SURVIVAL);
-            creator.setDifficulty(Difficulty.NORMAL);
+            uiState.setGameMode(WorldCreationUiState.SelectedGameMode.SURVIVAL);
+            uiState.setDifficulty(Difficulty.NORMAL);
         }
-        creator.setCheatsEnabled(false);
+        uiState.setAllowCommands(false);
 
-        SpawnHuntMod.LOGGER.info("SpawnHunt: auto-creating world '{}'", creator.getWorldName());
+        SpawnHuntMod.LOGGER.info("SpawnHunt: auto-creating world '{}'", uiState.getName());
 
-        // Schedule createLevel() on the next tick so init() finishes first
-        MinecraftClient.getInstance().send(this::createLevel);
+        // Schedule onCreate() on the next tick so init() finishes first
+        Minecraft.getInstance().execute(this::onCreate);
     }
 }

--- a/src/main/java/com/spawnhunt/mixin/GameModeLockMixin.java
+++ b/src/main/java/com/spawnhunt/mixin/GameModeLockMixin.java
@@ -1,39 +1,38 @@
 package com.spawnhunt.mixin;
 
 import com.spawnhunt.data.HuntState;
-import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
-import net.minecraft.world.GameMode;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.network.chat.Component;
+import net.minecraft.ChatFormatting;
+import net.minecraft.world.level.GameType;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin(ServerPlayerEntity.class)
+@Mixin(ServerPlayer.class)
 public abstract class GameModeLockMixin {
 
-    @Inject(method = "changeGameMode", at = @At("HEAD"), cancellable = true)
-    private void spawnhunt$blockGameModeChange(GameMode gameMode, CallbackInfoReturnable<Boolean> cir) {
-        ServerPlayerEntity self = (ServerPlayerEntity) (Object) this;
+    @Inject(method = "setGameMode", at = @At("HEAD"), cancellable = true)
+    private void spawnhunt$blockGameModeChange(GameType gameType, CallbackInfoReturnable<Boolean> cir) {
+        ServerPlayer self = (ServerPlayer) (Object) this;
 
         // Only lock on integrated server (singleplayer / open-to-LAN)
-        if (self.getEntityWorld().getServer().isDedicated()) return;
+        if (self.level().getServer().isDedicatedServer()) return;
 
         // Only lock during active, unwon hunts
         if (!HuntState.isActive() || HuntState.isWon()) return;
 
         // Allow staying in survival
-        if (gameMode == GameMode.SURVIVAL) return;
+        if (gameType == GameType.SURVIVAL) return;
 
         // Allow spectator when dead (hardcore death → "Spectate World")
-        if (gameMode == GameMode.SPECTATOR && self.isDead()) return;
+        if (gameType == GameType.SPECTATOR && self.isDeadOrDying()) return;
 
         // Block all other game mode changes
-        self.sendMessage(
-                Text.literal("[SpawnHunt] Game mode locked to Survival during active hunt.")
-                        .formatted(Formatting.RED),
-                false
+        self.sendSystemMessage(
+                Component.literal("[SpawnHunt] Game mode locked to Survival during active hunt.")
+                        .withStyle(ChatFormatting.RED)
         );
         cir.setReturnValue(false);
     }

--- a/src/main/java/com/spawnhunt/mixin/TitleScreenMixin.java
+++ b/src/main/java/com/spawnhunt/mixin/TitleScreenMixin.java
@@ -1,11 +1,11 @@
 package com.spawnhunt.mixin;
 
 import com.spawnhunt.screen.SpawnHuntScreen;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.TitleScreen;
-import net.minecraft.client.gui.widget.ButtonWidget;
-import net.minecraft.text.Text;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.TitleScreen;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.network.chat.Component;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -14,17 +14,17 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(TitleScreen.class)
 public abstract class TitleScreenMixin extends Screen {
 
-    protected TitleScreenMixin(Text title) {
+    protected TitleScreenMixin(Component title) {
         super(title);
     }
 
     @Inject(method = "init", at = @At("TAIL"))
     private void addSpawnHuntButton(CallbackInfo ci) {
-        this.addDrawableChild(
-                ButtonWidget.builder(Text.literal("SpawnHunt"), button -> {
-                    MinecraftClient.getInstance().setScreen(new SpawnHuntScreen());
+        this.addRenderableWidget(
+                Button.builder(Component.literal("SpawnHunt"), button -> {
+                    Minecraft.getInstance().setScreen(new SpawnHuntScreen());
                 })
-                .dimensions(this.width / 2 - 100, this.height / 4 + 156, 200, 20)
+                .bounds(this.width / 2 - 100, this.height / 4 + 156, 200, 20)
                 .build()
         );
     }

--- a/src/main/java/com/spawnhunt/network/ClientHuntState.java
+++ b/src/main/java/com/spawnhunt/network/ClientHuntState.java
@@ -1,6 +1,6 @@
 package com.spawnhunt.network;
 
-import net.minecraft.util.Identifier;
+import net.minecraft.resources.Identifier;
 
 /**
  * Client-side mirror of the server's hunt state, updated via network packets.
@@ -17,7 +17,7 @@ public class ClientHuntState {
     public static void update(HuntSyncS2CPayload payload) {
         active = payload.active();
         targetItem = (payload.active() && !payload.targetItemId().isEmpty())
-                ? Identifier.of(payload.targetItemId()) : null;
+                ? Identifier.parse(payload.targetItemId()) : null;
         elapsedMs = payload.elapsedMs();
         won = payload.won();
         winnerName = payload.winnerName();
@@ -28,7 +28,7 @@ public class ClientHuntState {
         won = true;
         winnerName = payload.winnerName();
         finalTimeMs = payload.finalTimeMs();
-        targetItem = Identifier.of(payload.targetItemId());
+        targetItem = Identifier.parse(payload.targetItemId());
     }
 
     public static void reset() {

--- a/src/main/java/com/spawnhunt/network/ClientHuntState.java
+++ b/src/main/java/com/spawnhunt/network/ClientHuntState.java
@@ -17,7 +17,7 @@ public class ClientHuntState {
     public static void update(HuntSyncS2CPayload payload) {
         active = payload.active();
         targetItem = (payload.active() && !payload.targetItemId().isEmpty())
-                ? Identifier.parse(payload.targetItemId()) : null;
+                ? Identifier.tryParse(payload.targetItemId()) : null;
         elapsedMs = payload.elapsedMs();
         won = payload.won();
         winnerName = payload.winnerName();
@@ -28,7 +28,7 @@ public class ClientHuntState {
         won = true;
         winnerName = payload.winnerName();
         finalTimeMs = payload.finalTimeMs();
-        targetItem = Identifier.parse(payload.targetItemId());
+        targetItem = Identifier.tryParse(payload.targetItemId());
     }
 
     public static void reset() {

--- a/src/main/java/com/spawnhunt/network/HuntSyncS2CPayload.java
+++ b/src/main/java/com/spawnhunt/network/HuntSyncS2CPayload.java
@@ -1,9 +1,9 @@
 package com.spawnhunt.network;
 
-import net.minecraft.network.RegistryByteBuf;
-import net.minecraft.network.codec.PacketCodec;
-import net.minecraft.network.packet.CustomPayload;
-import net.minecraft.util.Identifier;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.Identifier;
 
 public record HuntSyncS2CPayload(
         boolean active,
@@ -12,37 +12,37 @@ public record HuntSyncS2CPayload(
         boolean won,
         String winnerName,
         long finalTimeMs
-) implements CustomPayload {
+) implements CustomPacketPayload {
 
-    public static final Id<HuntSyncS2CPayload> ID =
-            new Id<>(Identifier.of("spawnhunt", "hunt_sync"));
+    public static final Type<HuntSyncS2CPayload> ID =
+            new Type<>(Identifier.fromNamespaceAndPath("spawnhunt", "hunt_sync"));
 
-    public static final PacketCodec<RegistryByteBuf, HuntSyncS2CPayload> CODEC = new PacketCodec<>() {
+    public static final StreamCodec<RegistryFriendlyByteBuf, HuntSyncS2CPayload> CODEC = new StreamCodec<>() {
         @Override
-        public HuntSyncS2CPayload decode(RegistryByteBuf buf) {
+        public HuntSyncS2CPayload decode(RegistryFriendlyByteBuf buf) {
             return new HuntSyncS2CPayload(
                     buf.readBoolean(),
-                    buf.readString(256),
+                    buf.readUtf(256),
                     buf.readLong(),
                     buf.readBoolean(),
-                    buf.readString(64),
+                    buf.readUtf(64),
                     buf.readLong()
             );
         }
 
         @Override
-        public void encode(RegistryByteBuf buf, HuntSyncS2CPayload payload) {
+        public void encode(RegistryFriendlyByteBuf buf, HuntSyncS2CPayload payload) {
             buf.writeBoolean(payload.active);
-            buf.writeString(payload.targetItemId);
+            buf.writeUtf(payload.targetItemId);
             buf.writeLong(payload.elapsedMs);
             buf.writeBoolean(payload.won);
-            buf.writeString(payload.winnerName);
+            buf.writeUtf(payload.winnerName);
             buf.writeLong(payload.finalTimeMs);
         }
     };
 
     @Override
-    public Id<? extends CustomPayload> getId() {
+    public Type<? extends CustomPacketPayload> type() {
         return ID;
     }
 }

--- a/src/main/java/com/spawnhunt/network/HuntWinS2CPayload.java
+++ b/src/main/java/com/spawnhunt/network/HuntWinS2CPayload.java
@@ -1,39 +1,39 @@
 package com.spawnhunt.network;
 
-import net.minecraft.network.RegistryByteBuf;
-import net.minecraft.network.codec.PacketCodec;
-import net.minecraft.network.packet.CustomPayload;
-import net.minecraft.util.Identifier;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.Identifier;
 
 public record HuntWinS2CPayload(
         String winnerName,
         long finalTimeMs,
         String targetItemId
-) implements CustomPayload {
+) implements CustomPacketPayload {
 
-    public static final Id<HuntWinS2CPayload> ID =
-            new Id<>(Identifier.of("spawnhunt", "hunt_win"));
+    public static final Type<HuntWinS2CPayload> ID =
+            new Type<>(Identifier.fromNamespaceAndPath("spawnhunt", "hunt_win"));
 
-    public static final PacketCodec<RegistryByteBuf, HuntWinS2CPayload> CODEC = new PacketCodec<>() {
+    public static final StreamCodec<RegistryFriendlyByteBuf, HuntWinS2CPayload> CODEC = new StreamCodec<>() {
         @Override
-        public HuntWinS2CPayload decode(RegistryByteBuf buf) {
+        public HuntWinS2CPayload decode(RegistryFriendlyByteBuf buf) {
             return new HuntWinS2CPayload(
-                    buf.readString(64),
+                    buf.readUtf(64),
                     buf.readLong(),
-                    buf.readString(256)
+                    buf.readUtf(256)
             );
         }
 
         @Override
-        public void encode(RegistryByteBuf buf, HuntWinS2CPayload payload) {
-            buf.writeString(payload.winnerName);
+        public void encode(RegistryFriendlyByteBuf buf, HuntWinS2CPayload payload) {
+            buf.writeUtf(payload.winnerName);
             buf.writeLong(payload.finalTimeMs);
-            buf.writeString(payload.targetItemId);
+            buf.writeUtf(payload.targetItemId);
         }
     };
 
     @Override
-    public Id<? extends CustomPayload> getId() {
+    public Type<? extends CustomPacketPayload> type() {
         return ID;
     }
 }

--- a/src/main/java/com/spawnhunt/network/SpawnHuntPayloads.java
+++ b/src/main/java/com/spawnhunt/network/SpawnHuntPayloads.java
@@ -5,7 +5,7 @@ import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 public class SpawnHuntPayloads {
 
     public static void register() {
-        PayloadTypeRegistry.playS2C().register(HuntSyncS2CPayload.ID, HuntSyncS2CPayload.CODEC);
-        PayloadTypeRegistry.playS2C().register(HuntWinS2CPayload.ID, HuntWinS2CPayload.CODEC);
+        PayloadTypeRegistry.clientboundPlay().register(HuntSyncS2CPayload.ID, HuntSyncS2CPayload.CODEC);
+        PayloadTypeRegistry.clientboundPlay().register(HuntWinS2CPayload.ID, HuntWinS2CPayload.CODEC);
     }
 }

--- a/src/main/java/com/spawnhunt/screen/ItemChooserScreen.java
+++ b/src/main/java/com/spawnhunt/screen/ItemChooserScreen.java
@@ -1,16 +1,16 @@
 package com.spawnhunt.screen;
 
 import com.spawnhunt.data.ItemPool;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.widget.AlwaysSelectedEntryListWidget;
-import net.minecraft.client.gui.widget.ButtonWidget;
-import net.minecraft.client.gui.widget.TextFieldWidget;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.client.gui.Click;
-import net.minecraft.text.Text;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.components.ObjectSelectionList;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.client.input.MouseButtonEvent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.util.Util;
 
 import java.util.ArrayList;
@@ -21,13 +21,13 @@ import java.util.Locale;
 public class ItemChooserScreen extends Screen {
     private final Item currentItem;
     private final boolean hardcore;
-    private TextFieldWidget searchField;
+    private EditBox searchField;
     private ItemListWidget itemList;
-    private ButtonWidget selectButton;
+    private Button selectButton;
     private List<Item> sortedItems;
 
     public ItemChooserScreen(Item currentItem, boolean hardcore) {
-        super(Text.literal("Choose Item"));
+        super(Component.literal("Choose Item"));
         this.currentItem = currentItem;
         this.hardcore = hardcore;
     }
@@ -38,36 +38,36 @@ public class ItemChooserScreen extends Screen {
         sortedItems.sort(Comparator.comparing(item ->
                 ItemPool.getDisplayName(item).getString().toLowerCase(Locale.ROOT)));
 
-        searchField = new TextFieldWidget(this.textRenderer, this.width / 2 - 100, 22, 200, 20, Text.literal("Search"));
-        searchField.setChangedListener(text -> refreshList());
-        this.addDrawableChild(searchField);
+        searchField = new EditBox(this.getFont(), this.width / 2 - 100, 22, 200, 20, Component.literal("Search"));
+        searchField.setResponder(text -> refreshList());
+        this.addRenderableWidget(searchField);
 
-        itemList = new ItemListWidget(this.client, this.width, this.height - 84, 48, 20);
-        this.addDrawableChild(itemList);
+        itemList = new ItemListWidget(this.minecraft, this.width, this.height - 84, 48, 20);
+        this.addRenderableWidget(itemList);
 
         refreshList();
 
-        this.addDrawableChild(
-                ButtonWidget.builder(Text.literal("Back"), button -> close())
-                        .dimensions(this.width / 2 - 104, this.height - 28, 100, 20).build()
+        this.addRenderableWidget(
+                Button.builder(Component.literal("Back"), button -> onClose())
+                        .bounds(this.width / 2 - 104, this.height - 28, 100, 20).build()
         );
 
-        selectButton = ButtonWidget.builder(Text.literal("Select"), button -> selectAndReturn())
-                .dimensions(this.width / 2 + 4, this.height - 28, 100, 20).build();
-        this.addDrawableChild(selectButton);
+        selectButton = Button.builder(Component.literal("Select"), button -> selectAndReturn())
+                .bounds(this.width / 2 + 4, this.height - 28, 100, 20).build();
+        this.addRenderableWidget(selectButton);
 
         this.setInitialFocus(searchField);
     }
 
     void selectAndReturn() {
-        ItemListWidget.Entry entry = itemList.getSelectedOrNull();
+        ItemListWidget.Entry entry = itemList.getSelected();
         if (entry != null) {
-            this.client.setScreen(new SpawnHuntScreen(entry.getItem(), this.hardcore));
+            this.minecraft.setScreen(new SpawnHuntScreen(entry.getItem(), this.hardcore));
         }
     }
 
     private void refreshList() {
-        String query = searchField.getText().toLowerCase(Locale.ROOT).trim();
+        String query = searchField.getValue().toLowerCase(Locale.ROOT).trim();
         itemList.clearEntries();
 
         ItemListWidget.Entry toSelect = null;
@@ -85,24 +85,24 @@ public class ItemChooserScreen extends Screen {
             itemList.setSelected(toSelect);
             itemList.centerScrollOn(toSelect);
         } else {
-            itemList.setScrollY(0);
+            itemList.setScrollAmount(0);
         }
     }
 
     @Override
-    public void render(DrawContext context, int mouseX, int mouseY, float delta) {
-        super.render(context, mouseX, mouseY, delta);
-        context.drawCenteredTextWithShadow(this.textRenderer, this.title, this.width / 2, 8, 0xFFFFFF);
-        selectButton.active = itemList.getSelectedOrNull() != null;
+    public void extractRenderState(GuiGraphicsExtractor context, int mouseX, int mouseY, float delta) {
+        super.extractRenderState(context, mouseX, mouseY, delta);
+        context.centeredText(this.getFont(), this.title, this.width / 2, 8, 0xFFFFFF);
+        selectButton.active = itemList.getSelected() != null;
     }
 
     @Override
-    public void close() {
-        this.client.setScreen(new SpawnHuntScreen(currentItem, this.hardcore));
+    public void onClose() {
+        this.minecraft.setScreen(new SpawnHuntScreen(currentItem, this.hardcore));
     }
 
-    class ItemListWidget extends AlwaysSelectedEntryListWidget<ItemListWidget.Entry> {
-        public ItemListWidget(MinecraftClient client, int width, int height, int y, int itemHeight) {
+    class ItemListWidget extends ObjectSelectionList<ItemListWidget.Entry> {
+        public ItemListWidget(Minecraft client, int width, int height, int y, int itemHeight) {
             super(client, width, height, y, itemHeight);
         }
 
@@ -127,9 +127,9 @@ public class ItemChooserScreen extends Screen {
             return entry;
         }
 
-        class Entry extends AlwaysSelectedEntryListWidget.Entry<Entry> {
+        class Entry extends ObjectSelectionList.Entry<Entry> {
             private final Item item;
-            private final Text displayName;
+            private final Component displayName;
             private long lastClickTime;
 
             public Entry(Item item) {
@@ -142,23 +142,23 @@ public class ItemChooserScreen extends Screen {
             }
 
             @Override
-            public void render(DrawContext context, int mouseX, int mouseY, boolean hovered, float delta) {
-                int x = this.getX();
-                int y = this.getY();
-                context.drawItem(new ItemStack(item), x + 2, y + 1);
-                context.drawText(ItemChooserScreen.this.textRenderer, displayName,
+            public void extractContent(GuiGraphicsExtractor context, int mouseX, int mouseY, boolean hovered, float delta) {
+                int x = this.getContentX();
+                int y = this.getContentY();
+                context.item(new ItemStack(item), x + 2, y + 1);
+                context.text(Minecraft.getInstance().font, displayName,
                         x + 24, y + 5, 0xFFFFFFFF, true);
             }
 
             @Override
-            public Text getNarration() {
+            public Component getNarration() {
                 return displayName;
             }
 
             @Override
-            public boolean mouseClicked(Click click, boolean selected) {
+            public boolean mouseClicked(MouseButtonEvent event, boolean selected) {
                 ItemListWidget.this.setSelected(this);
-                long now = Util.getMeasuringTimeMs();
+                long now = Util.getMillis();
                 if (now - lastClickTime < 250L) {
                     ItemChooserScreen.this.selectAndReturn();
                 }

--- a/src/main/java/com/spawnhunt/screen/SpawnHuntScreen.java
+++ b/src/main/java/com/spawnhunt/screen/SpawnHuntScreen.java
@@ -3,21 +3,21 @@ package com.spawnhunt.screen;
 import com.spawnhunt.data.HuntState;
 import com.spawnhunt.data.ItemPool;
 import com.spawnhunt.data.ResultStore;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.Click;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.TitleScreen;
-import net.minecraft.client.gui.screen.world.CreateWorldScreen;
-import net.minecraft.client.gui.widget.ButtonWidget;
-import net.minecraft.client.gui.widget.CheckboxWidget;
-import net.minecraft.client.sound.PositionedSoundInstance;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.registry.Registries;
-import net.minecraft.sound.SoundEvents;
-import net.minecraft.text.Text;
-import net.minecraft.util.Identifier;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.input.MouseButtonEvent;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.TitleScreen;
+import net.minecraft.client.gui.screens.worldselection.CreateWorldScreen;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.Checkbox;
+import net.minecraft.client.resources.sounds.SimpleSoundInstance;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -65,15 +65,16 @@ public class SpawnHuntScreen extends Screen {
     private Item displayItem;          // item currently shown (rolling item or final target)
 
     // Button references for enabling/disabling during roll
-    private ButtonWidget startButton;
-    private ButtonWidget rerollButton;
-    private ButtonWidget listButton;
+    private Button startButton;
+    private Button rerollButton;
+    private Button listButton;
 
     // Clickable "History" / "Back" link bounds (set during render)
     private int historyLinkX, historyLinkY, historyLinkW, historyLinkH;
 
     public SpawnHuntScreen() {
-        super(Text.literal("SpawnHunt"));
+        super(Component.literal("SpawnHunt"));
+        ItemPool.ensureComponentsBound();
         this.targetItem = ItemPool.getRandomItem(random);
         this.displayItem = this.targetItem;
         this.hardcore = true;
@@ -85,7 +86,7 @@ public class SpawnHuntScreen extends Screen {
     }
 
     public SpawnHuntScreen(Item preselectedItem, boolean hardcore) {
-        super(Text.literal("SpawnHunt"));
+        super(Component.literal("SpawnHunt"));
         this.targetItem = preselectedItem;
         this.displayItem = preselectedItem;
         this.hardcore = hardcore;
@@ -108,52 +109,52 @@ public class SpawnHuntScreen extends Screen {
         int rightBtnX = centerX + BTN_GAP / 2;
 
         // Row 1: Start, Reroll
-        this.startButton = this.addDrawableChild(
-                ButtonWidget.builder(Text.literal("Start"), button -> {
-                    HuntState.startHunt(Registries.ITEM.getId(targetItem), this.hardcore);
-                    CreateWorldScreen.show(this.client, () -> {
-                        this.client.setScreen(new TitleScreen());
+        this.startButton = this.addRenderableWidget(
+                Button.builder(Component.literal("Start"), button -> {
+                    HuntState.startHunt(BuiltInRegistries.ITEM.getKey(targetItem), this.hardcore);
+                    CreateWorldScreen.openFresh(this.minecraft, () -> {
+                        this.minecraft.setScreen(new TitleScreen());
                     });
                 })
-                .dimensions(leftBtnX, btnBlockY, BTN_W, BTN_H)
+                .bounds(leftBtnX, btnBlockY, BTN_W, BTN_H)
                 .build()
         );
 
-        this.rerollButton = this.addDrawableChild(
-                ButtonWidget.builder(Text.literal("Reroll"), button -> {
+        this.rerollButton = this.addRenderableWidget(
+                Button.builder(Component.literal("Reroll"), button -> {
                     this.targetItem = ItemPool.getRandomItem(random);
                     this.showHistory = false;
                     startRolling();
                 })
-                .dimensions(rightBtnX, btnBlockY, BTN_W, BTN_H)
+                .bounds(rightBtnX, btnBlockY, BTN_W, BTN_H)
                 .build()
         );
 
         // Row 2: List, Cancel
         int row2Y = btnBlockY + BTN_H + BTN_GAP;
-        this.listButton = this.addDrawableChild(
-                ButtonWidget.builder(Text.literal("List"), button -> {
-                    this.client.setScreen(new ItemChooserScreen(this.targetItem, this.hardcore));
+        this.listButton = this.addRenderableWidget(
+                Button.builder(Component.literal("List"), button -> {
+                    this.minecraft.setScreen(new ItemChooserScreen(this.targetItem, this.hardcore));
                 })
-                .dimensions(leftBtnX, row2Y, BTN_W, BTN_H)
+                .bounds(leftBtnX, row2Y, BTN_W, BTN_H)
                 .build()
         );
 
-        this.addDrawableChild(
-                ButtonWidget.builder(Text.literal("Cancel"), button -> {
-                    this.client.setScreen(new TitleScreen());
+        this.addRenderableWidget(
+                Button.builder(Component.literal("Cancel"), button -> {
+                    this.minecraft.setScreen(new TitleScreen());
                 })
-                .dimensions(rightBtnX, row2Y, BTN_W, BTN_H)
+                .bounds(rightBtnX, row2Y, BTN_W, BTN_H)
                 .build()
         );
 
         // Hardcore checkbox — centered below buttons
         int checkboxY = row2Y + BTN_H + GAP_MEDIUM;
-        this.addDrawableChild(
-                CheckboxWidget.builder(Text.literal("Hardcore"), this.textRenderer)
+        this.addRenderableWidget(
+                Checkbox.builder(Component.literal("Hardcore"), this.getFont())
                         .pos(centerX - 30, checkboxY)
-                        .checked(this.hardcore)
-                        .callback((checkbox, checked) -> this.hardcore = checked)
+                        .selected(this.hardcore)
+                        .onValueChange((checkbox, checked) -> this.hardcore = checked)
                         .build()
         );
 
@@ -205,8 +206,8 @@ public class SpawnHuntScreen extends Screen {
 
             // Play click sound for each intermediate item (not the final reveal)
             if (!isFinal) {
-                MinecraftClient.getInstance().getSoundManager()
-                        .play(PositionedSoundInstance.ui(SoundEvents.UI_BUTTON_CLICK.value(), 1.0f));
+                Minecraft.getInstance().getSoundManager()
+                        .play(SimpleSoundInstance.forUI(SoundEvents.UI_BUTTON_CLICK.value(), 1.0f));
             }
 
             // Stop rolling when we reach the final item
@@ -225,7 +226,7 @@ public class SpawnHuntScreen extends Screen {
     }
 
     @Override
-    public void render(DrawContext context, int mouseX, int mouseY, float delta) {
+    public void extractRenderState(GuiGraphicsExtractor context, int mouseX, int mouseY, float delta) {
         // Deferred roll start (sound manager not available in constructor)
         if (rollPending) {
             rollPending = false;
@@ -238,22 +239,22 @@ public class SpawnHuntScreen extends Screen {
         // Dark background
         context.fill(0, 0, this.width, this.height, 0xC0000000);
 
-        super.render(context, mouseX, mouseY, delta);
+        super.extractRenderState(context, mouseX, mouseY, delta);
 
         int centerX = this.width / 2;
         int topY = (this.height - TOTAL_HEIGHT) / 2;
         int curY = topY;
 
         // Title
-        Text title = Text.literal("SpawnHunt");
-        context.drawText(this.textRenderer, title,
-                centerX - this.textRenderer.getWidth(title) / 2, curY, 0xFFFFFFFF, true);
+        Component title = Component.literal("SpawnHunt");
+        context.text(this.getFont(), title,
+                centerX - this.getFont().width(title) / 2, curY, 0xFFFFFFFF, true);
         curY += TEXT_H + GAP_SMALL;
 
         // Subtitle
-        Text subtitle = Text.literal("Your target:");
-        context.drawText(this.textRenderer, subtitle,
-                centerX - this.textRenderer.getWidth(subtitle) / 2, curY, 0xFFAAAAAA, true);
+        Component subtitle = Component.literal("Your target:");
+        context.text(this.getFont(), subtitle,
+                centerX - this.getFont().width(subtitle) / 2, curY, 0xFFAAAAAA, true);
         curY += TEXT_H + GAP_MEDIUM;
 
         // Icon area (or history panels)
@@ -271,30 +272,30 @@ public class SpawnHuntScreen extends Screen {
                 iconY = (int) (iconAreaY + bob);
             }
 
-            context.getMatrices().pushMatrix();
-            context.getMatrices().translate((float) (centerX - ICON_SIZE / 2), (float) iconY);
-            context.getMatrices().scale((float) ICON_SCALE, (float) ICON_SCALE);
-            context.drawItem(new ItemStack(displayItem), 0, 0);
-            context.getMatrices().popMatrix();
+            context.pose().pushMatrix();
+            context.pose().translate((float) (centerX - ICON_SIZE / 2), (float) iconY);
+            context.pose().scale((float) ICON_SCALE, (float) ICON_SCALE);
+            context.item(new ItemStack(displayItem), 0, 0);
+            context.pose().popMatrix();
         }
         curY += ICON_SIZE + GAP_SMALL;
 
         // Item name
-        Text itemName = ItemPool.getDisplayName(displayItem);
+        Component itemName = ItemPool.getDisplayName(displayItem);
         int nameColor = isRolling ? 0xFF888888 : 0xFFFFFF00;
-        context.drawText(this.textRenderer, itemName,
-                centerX - this.textRenderer.getWidth(itemName) / 2, curY, nameColor, true);
+        context.text(this.getFont(), itemName,
+                centerX - this.getFont().width(itemName) / 2, curY, nameColor, true);
         curY += TEXT_H + GAP_SMALL;
 
         // History toggle link (hidden during rolling)
         if (!isRolling) {
-            Text linkText = Text.literal(showHistory ? "< Back" : "History >");
-            int linkW = this.textRenderer.getWidth(linkText);
+            Component linkText = Component.literal(showHistory ? "< Back" : "History >");
+            int linkW = this.getFont().width(linkText);
             int linkX = centerX - linkW / 2;
             boolean hovering = mouseX >= linkX && mouseX <= linkX + linkW
                     && mouseY >= curY && mouseY <= curY + TEXT_H;
             int linkColor = hovering ? 0xFF88CCFF : 0xFF6699CC;
-            context.drawText(this.textRenderer, linkText, linkX, curY, linkColor, true);
+            context.text(this.getFont(), linkText, linkX, curY, linkColor, true);
 
             historyLinkX = linkX;
             historyLinkY = curY;
@@ -307,8 +308,8 @@ public class SpawnHuntScreen extends Screen {
         }
     }
 
-    private void renderHistoryArea(DrawContext context, int centerX, int areaY) {
-        Identifier itemId = Registries.ITEM.getId(targetItem);
+    private void renderHistoryArea(GuiGraphicsExtractor context, int centerX, int areaY) {
+        Identifier itemId = BuiltInRegistries.ITEM.getKey(targetItem);
         List<ResultStore.RunResult> lastRuns = ResultStore.getLastRuns(itemId, 3);
         List<ResultStore.RunResult> topRuns = ResultStore.getTopRuns(itemId, 3);
 
@@ -330,27 +331,27 @@ public class SpawnHuntScreen extends Screen {
     }
 
     private int computePanelWidth(String header) {
-        return (int) (this.textRenderer.getWidth(header) * PANEL_SCALE) + PANEL_PADDING * 2;
+        return (int) (this.getFont().width(header) * PANEL_SCALE) + PANEL_PADDING * 2;
     }
 
     private int computePanelHeight(int entryCount) {
-        int scaledLineHeight = (int) ((this.textRenderer.fontHeight + 2) * PANEL_SCALE);
+        int scaledLineHeight = (int) ((this.getFont().lineHeight + 2) * PANEL_SCALE);
         return PANEL_PADDING + scaledLineHeight + 2 + Math.max(entryCount, 1) * scaledLineHeight + PANEL_PADDING;
     }
 
     @Override
-    public boolean mouseClicked(Click click, boolean doubled) {
-        if (click.button() == 0 && click.x() >= historyLinkX && click.x() <= historyLinkX + historyLinkW
-                && click.y() >= historyLinkY && click.y() <= historyLinkY + historyLinkH) {
+    public boolean mouseClicked(MouseButtonEvent event, boolean selected) {
+        if (event.button() == 0 && (int) event.x() >= historyLinkX && (int) event.x() <= historyLinkX + historyLinkW
+                && (int) event.y() >= historyLinkY && (int) event.y() <= historyLinkY + historyLinkH) {
             showHistory = !showHistory;
             return true;
         }
-        return super.mouseClicked(click, doubled);
+        return super.mouseClicked(event, selected);
     }
 
-    private void renderRunPanel(DrawContext context, int x, int y, String header,
+    private void renderRunPanel(GuiGraphicsExtractor context, int x, int y, String header,
                                 List<ResultStore.RunResult> runs, int panelW) {
-        int scaledLineHeight = (int) ((this.textRenderer.fontHeight + 2) * PANEL_SCALE);
+        int scaledLineHeight = (int) ((this.getFont().lineHeight + 2) * PANEL_SCALE);
         int panelH = PANEL_PADDING + scaledLineHeight + 2 + Math.max(runs.size(), 1) * scaledLineHeight + PANEL_PADDING;
 
         // Background + border
@@ -358,33 +359,33 @@ public class SpawnHuntScreen extends Screen {
         drawPanelBorder(context, x, y, panelW, panelH);
 
         // Header (scaled)
-        context.getMatrices().pushMatrix();
-        context.getMatrices().translate((float) (x + PANEL_PADDING), (float) (y + PANEL_PADDING));
-        context.getMatrices().scale(PANEL_SCALE, PANEL_SCALE);
-        context.drawText(this.textRenderer, header, 0, 0, 0xFFFFFFFF, true);
-        context.getMatrices().popMatrix();
+        context.pose().pushMatrix();
+        context.pose().translate((float) (x + PANEL_PADDING), (float) (y + PANEL_PADDING));
+        context.pose().scale(PANEL_SCALE, PANEL_SCALE);
+        context.text(this.getFont(), header, 0, 0, 0xFFFFFFFF, true);
+        context.pose().popMatrix();
 
         int entryY = y + PANEL_PADDING + scaledLineHeight + 2;
 
         if (runs.isEmpty()) {
-            context.getMatrices().pushMatrix();
-            context.getMatrices().translate((float) (x + PANEL_PADDING), (float) entryY);
-            context.getMatrices().scale(PANEL_SCALE, PANEL_SCALE);
-            context.drawText(this.textRenderer, "No runs yet", 0, 0, 0xFF888888, true);
-            context.getMatrices().popMatrix();
+            context.pose().pushMatrix();
+            context.pose().translate((float) (x + PANEL_PADDING), (float) entryY);
+            context.pose().scale(PANEL_SCALE, PANEL_SCALE);
+            context.text(this.getFont(), "No runs yet", 0, 0, 0xFF888888, true);
+            context.pose().popMatrix();
         } else {
             for (int i = 0; i < runs.size(); i++) {
                 String entry = (i + 1) + ". " + HuntState.formatTime(runs.get(i).timeMs);
-                context.getMatrices().pushMatrix();
-                context.getMatrices().translate((float) (x + PANEL_PADDING), (float) (entryY + i * scaledLineHeight));
-                context.getMatrices().scale(PANEL_SCALE, PANEL_SCALE);
-                context.drawText(this.textRenderer, entry, 0, 0, 0xFFDDDDDD, true);
-                context.getMatrices().popMatrix();
+                context.pose().pushMatrix();
+                context.pose().translate((float) (x + PANEL_PADDING), (float) (entryY + i * scaledLineHeight));
+                context.pose().scale(PANEL_SCALE, PANEL_SCALE);
+                context.text(this.getFont(), entry, 0, 0, 0xFFDDDDDD, true);
+                context.pose().popMatrix();
             }
         }
     }
 
-    private static void drawPanelBorder(DrawContext context, int x, int y, int w, int h) {
+    private static void drawPanelBorder(GuiGraphicsExtractor context, int x, int y, int w, int h) {
         context.fill(x, y, x + w, y + 1, PANEL_BORDER);         // top
         context.fill(x, y + h - 1, x + w, y + h, PANEL_BORDER); // bottom
         context.fill(x, y, x + 1, y + h, PANEL_BORDER);         // left

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,7 +23,7 @@
   "depends": {
     "fabricloader": ">=0.18.0",
     "fabric-api": "*",
-    "minecraft": "~1.21.11",
-    "java": ">=21"
+    "minecraft": "~26.1",
+    "java": ">=25"
   }
 }

--- a/src/main/resources/spawnhunt.accesswidener
+++ b/src/main/resources/spawnhunt.accesswidener
@@ -1,2 +1,2 @@
-accessWidener v2 named
-accessible method net/minecraft/client/gui/screen/world/CreateWorldScreen createLevel ()V
+accessWidener v2 official
+accessible method net/minecraft/client/gui/screens/worldselection/CreateWorldScreen onCreate ()V

--- a/src/main/resources/spawnhunt.mixins.json
+++ b/src/main/resources/spawnhunt.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "com.spawnhunt.mixin",
-  "compatibilityLevel": "JAVA_21",
+  "compatibilityLevel": "JAVA_25",
   "mixins": [
     "GameModeLockMixin"
   ],


### PR DESCRIPTION
MC 26.1 is the first unobfuscated version, requiring a full port from
Yarn to Mojang mappings. This updates all 20 Java source files, the
build system, and resource files.

Build system:
- Gradle 9.2.1 → 9.4.0, Loom fabric-loom 1.15.4 → net.fabricmc.fabric-loom 1.16.1
- Java 21 → 25, Fabric API 0.141.3+1.21.11 → 0.144.4+26.1
- Removed Yarn mappings (26.1 is unobfuscated), modImplementation → implementation

Key API migrations:
- HudRenderCallback → HudElementRegistry.addLast()
- DrawContext → GuiGraphicsExtractor (item(), text(), centeredText())
- Screen.render() → extractRenderState(), Entry.render() → extractContent()
- CustomPayload → CustomPacketPayload, readString/writeString → readUtf/writeUtf
- PayloadTypeRegistry.playS2C() → clientboundPlay()
- WorldCreator → WorldCreationUiState, createLevel() → onCreate()
- GameMode → GameType, ServerPlayerEntity → ServerPlayer
- Access widener namespace: named → official

Pre-world item rendering:
- Item components are data-driven in 26.1 and not bound until world load
- Added ensureComponentsBound() to bind minimal ITEM_MODEL components
  from registry IDs, enabling ItemStack creation on the selection screen
- Vanilla overwrites with full components during world load