### PR TITLE
Bump release workflow to JDK 25

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,11 @@ jobs:
             exit 1
           fi
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
 
       - name: Build with Gradle
         run: ./gradlew build


### PR DESCRIPTION
MC 26.1 port requires Java 25 toolchain; the workflow was still pinned to JDK 21, causing "release version 25 not supported" on merge to main.