### PR TITLE
Tidy the release process

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -23,24 +23,19 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+      # mod_version is the single source of truth: build.gradle reads it into
+      # project.version, and processResources expands it into fabric.mod.json's
+      # ${version}. There is no other version number to keep in step.
       - name: Update mod_version in gradle.properties
         run: |
           sed -i "s/^mod_version=.*/mod_version=${{ steps.version.outputs.version }}/" gradle.properties
 
-      - name: Add version row to CLAUDE.md
-        run: |
-          DATE=$(date -u +%Y-%m-%d)
-          VERSION="${{ steps.version.outputs.version }}"
-          # Only insert if a row for this version doesn't already exist
-          if ! grep -q "| $VERSION |" CLAUDE.md; then
-            sed -i "/^|---------|------------|/a | $VERSION | $DATE |  |" CLAUDE.md
-          fi
-
+      # CHANGELOG.md is deliberately left alone — release notes are written by hand.
       - name: Commit version bump
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add gradle.properties CLAUDE.md
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
+          git add gradle.properties
+          git diff --cached --quiet && echo "Version already ${{ steps.version.outputs.version }}, nothing to commit" && exit 0
           git commit -m "Set version to ${{ steps.version.outputs.version }}"
           git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,21 @@ on:
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true
+    # Only a merged release/X.Y.Z branch cuts a release. A dev -> main or
+    # hotfix -> main merge builds nothing, so it can't re-cut a shipped version.
+    if: >-
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # Tags are needed for the duplicate-tag guard below. The default
+          # shallow checkout fetches none, which silently made that check a no-op.
+          fetch-depth: 0
 
       - name: Read version from gradle.properties
         id: version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,14 +121,14 @@ JAVA_HOME="/c/Program Files/Eclipse Adoptium/jdk-25.0.2.10-hotspot" ./gradlew bu
 - [x] M4 Client integration (ClientHuntState, packet receivers, dual-source HUD)
 - [x] M5 Polish (seconds-only timer for MP, win timer fix, action bar cleanup)
 
-### Phase 26.2 — Port to Minecraft 26.2 "Chaos Cubed" (4.0.0)
+### Phase 26.2 — Port to Minecraft 26.2 "Chaos Cubed"
 - [x] P1 Toolchain bump (MC 26.2, loader 0.19.3, fabric-api 0.157.0+26.2, Loom 1.17.19, Gradle 9.5.1)
 - [x] P2 Build reliability (scoped Fabric repo, raised HTTP timeouts)
 - [x] P3 Gui/Hud split migration (`Minecraft.gui.setScreen`, `Minecraft.gui.screen()`)
 - [x] P4 Verify mixin targets and access widener still resolve against 26.2
 - [x] P5 Audit the 31 new items for survival obtainability (no exclusions needed)
 
-### Phase H — Hardening (3.1.0, from the July 2026 code review)
+### Phase H — Hardening (from the July 2026 code review)
 - [x] H1 Server state lifecycle (reset `ServerHuntState` + tick counter on `SERVER_STOPPED`)
 - [x] H2 Game-mode gate on multiplayer wins (survival/adventure only)
 - [x] H3 Thread safety for shared statics (concurrent name cache, volatile pool + `HuntState.active`/`won`)
@@ -175,23 +175,26 @@ JAVA_HOME="/c/Program Files/Eclipse Adoptium/jdk-25.0.2.10-hotspot" ./gradlew bu
 - **Item pool accuracy** — maintain exclusion list carefully, log pool on startup, iterate via community feedback.
 - **Pre-world component binding** — `ensureComponentsBound()` binds minimal components before vanilla does. If vanilla changes the binding lifecycle or adds validation, this could break. Monitor across MC updates.
 
-## Versioning
+## Versioning & Release Process
 
-Uses [SemVer](https://semver.org/). Version is set in `gradle.properties` (`mod_version`).
+Uses [SemVer](https://semver.org/). **`CHANGELOG.md` is the version history — it is
+maintained by hand, and no automation writes to it. Don't add version tables here.**
 
-| Version | Date       | Notes                                    |
-|---------|------------|------------------------------------------|
-| 4.0.0 | 2026-08-13 | Port to MC 26.2: Gui/Hud split (`Minecraft.gui.setScreen`), Loom 1.17.19, Gradle 9.5.1, 31 new Chaos Cubed items in the pool |
-| 3.1.0 | 2026-08-13 | Server state lifecycle & game-mode fixes, thread safety, render/tick perf, composite payload codecs |
-| 3.0.0 | 2026-04-16 | Port to MC 26.1: Java 25, Mojang mappings, HudElementRegistry, unobfuscated build |
-| 2.2.1 | 2026-03-23 | Server players can immediately start a new hunt after winning |
-| 2.2.0 | 2026-03-22 | Slot machine rolling animation |
-| 2.1.0 | 2026-03-17 | Lock to survival during active singleplayer hunts |
-| 2.0.0 | 2026-03-16 | Multiplayer support: server commands, HUD sync, vanilla client action bar |
-| 1.3.0 | 2026-03-15 | HUD redesign, vertical menu layout, music disc naming, item pool fixes |
-| 1.2.0   | 2026-03-12 | Music disc song names, display name caching |
-| 1.1.0   | 2026-02-26 | UI polish, win state rework, world naming   |
-| 1.0.0   | 2026-02-26 | Initial public release on Modrinth          |
+`mod_version` in `gradle.properties` is the single source of truth for the version
+number: `build.gradle` reads it into `project.version`, and `processResources` expands
+it into `fabric.mod.json`'s `${version}`. Nothing else hardcodes a version.
+
+The release flow:
+
+1. Work lands on `dev`. You don't need to know the version number while working.
+2. When the work is complete, cut `release/X.Y.Z` from `dev`. The `Set Release Version`
+   workflow reads the version out of the branch name and commits the `mod_version` bump.
+3. Write the `CHANGELOG.md` entry by hand on the release branch.
+4. On approval, merge `release/X.Y.Z` into `main`. That builds the jar and publishes the
+   GitHub release, tagged `vX.Y.Z`, with notes taken from the top `CHANGELOG.md` section.
+5. Merge the release branch back into `dev` yourself — this is deliberately not automated.
+
+Only a merged `release/*` branch cuts a release; a `dev`/`hotfix` merge to `main` builds nothing.
 
 ## API Notes (MC 26.2)
 


### PR DESCRIPTION
Stacked on #33 — review that first. Base retargets to `dev` automatically when #33 merges.

The flow you already had is the right shape; this fixes three things around it.

## No automation writes docs

`release-branch.yml` was inserting a row into the CLAUDE.md version table on every push to a release branch. `CHANGELOG.md` is the version history and is maintained by hand, so that step is gone — and the CLAUDE.md version table with it, replaced by a description of the release process itself.

The workflow now rewrites exactly one thing: `mod_version` in `gradle.properties`. That's the single source of truth — `build.gradle` reads it into `project.version`, and `processResources` expands it into `fabric.mod.json`'s `${version}`. Nothing else in the repo hardcodes a version, so there's nothing else to keep in step.

## Only release branches cut releases

Previously *any* merged PR into `main` published a release. That's how **v3.0.0 shipped twice within five minutes on 30 April** — once from `hotfix/build-error` at 06:12, then again from a `dev` merge at 06:17. The job now also requires the head branch to start with `release/`.

⚠️ **Consequence:** a hotfix must now go out via a `release/X.Y.Z` branch. Merging it straight to `main` builds nothing.

## The duplicate-tag guard never worked

That second v3.0.0 run *should* have been stopped by the `Check tag does not already exist` step. It wasn't, because `actions/checkout` fetches no tags at its default `fetch-depth: 1` — so `git rev-parse refs/tags/vX.Y.Z` always failed and the guard always passed, letting the run overwrite the existing release's assets.

Checking out at `fetch-depth: 0` makes it real. Verified against the repo's actual tags: `v3.1.0` blocks, `v4.0.0` proceeds.

## Unchanged

The back-merge to `dev` stays manual and deliberately un-automated. Release notes are still taken from the top `CHANGELOG.md` section — read only, never written.

## Verification

Both workflows parse as valid YAML. Tested against real repo data: the branch-name version regex (accepts `release/4.1.0`, rejects `release/4.1` and `release/foo`), the `mod_version` sed, the changelog-extraction awk, and the tag guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)