### PR TITLE
Fail fast on a wrong build JVM and on a too-old Fabric API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,11 @@ Supports both singleplayer (client-side) and multiplayer (server-side commands +
 
 ## Testing Environment
 
-- **Minecraft instance (macOS):** `/Applications/MultiMC.app/Data/instances/SpawnHunt 26.2/.minecraft`
+- **Minecraft instance (macOS):** `/Applications/MultiMC.app/Data/instances/Family 26.2/.minecraft`
 - **Minecraft instance (Windows):** `C:\MultiMC\instances\SpawnHunt 26.2\.minecraft`
+- The instance's Fabric API must be **at least** `fabric_version` from `gradle.properties`;
+  `fabric.mod.json` declares that floor, so Fabric refuses to load with a clear message
+  instead of dying on a `NoSuchMethodError` mid-game.
 - Built `.jar` goes into the `mods/` folder of that instance
 - Requires Fabric Loader + Fabric API for MC 26.2
 
@@ -47,7 +50,9 @@ com.spawnhunt
 ## Tech Stack
 
 - **Build:** Gradle 9.5.1 + Fabric Loom 1.17.19 (`net.fabricmc.fabric-loom` — no-remap for unobfuscated MC)
-- **Java:** JDK 25 (Eclipse Adoptium 25.0.2+10) at `C:\Program Files\Eclipse Adoptium\jdk-25.0.2.10-hotspot`
+- **Java:** JDK 25 **or newer** — Gradle itself must run on it. Compilation pins `options.release = 25`,
+  so a newer JDK (26 etc.) is fine and no JDK 25 install is required. `settings.gradle` fails fast with
+  the fix if the JVM is too old.
 - **Dependencies:** fabric-loader 0.19.3, fabric-api 0.157.0+26.2
 - **Mappings:** None (MC 26.2 is unobfuscated — uses Mojang official names directly)
 - **Language:** Java
@@ -55,10 +60,21 @@ com.spawnhunt
 ## Build Commands
 
 ```bash
-# Build (must use JDK 25)
-JAVA_HOME="/c/Program Files/Eclipse Adoptium/jdk-25.0.2.10-hotspot" ./gradlew build
+# Build (needs a JDK 25+; usually just works if JAVA_HOME already points at one)
+./gradlew build
 
 # Output jar: build/libs/spawnhunt-<version>.jar
+```
+
+**If the build reports the wrong Java version, `JAVA_HOME` is not the thing to fix.**
+Gradle takes its JVM from `-Dorg.gradle.java.home` first, then `org.gradle.java.home` in
+**`~/.gradle/gradle.properties`**, and only then `JAVA_HOME`. A per-user gradle.properties
+pinning an old JDK outranks the environment and is the usual cause — exporting `JAVA_HOME`
+has no effect against it. Either fix that file or override per-invocation:
+
+```bash
+/usr/libexec/java_home -V                       # list installed JDKs (macOS)
+./gradlew build -Dorg.gradle.java.home=/path/to/jdk-25-or-newer
 ```
 
 ## Development Phases & Progress

--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,17 @@ dependencies {
 }
 
 processResources {
+    // The Fabric API version we compile against is also the minimum we claim to run on,
+    // so fabric.mod.json takes its floor from gradle.properties rather than a hand-kept
+    // copy that drifts. Strip the build suffix (0.157.0+26.2 -> 0.157.0): the predicate
+    // wants a bare version, and semver ignores build metadata when comparing anyway.
+    def fabricApiMinimum = project.fabric_version.split('\\+')[0]
+
     inputs.property "version", project.version
+    inputs.property "fabric_api_minimum", fabricApiMinimum
 
     filesMatching("fabric.mod.json") {
-        expand "version": project.version
+        expand "version": project.version, "fabric_api_minimum": fabricApiMinimum
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,4 +14,27 @@ pluginManagement {
     }
 }
 
+// Loom 1.17 refuses to resolve on a JVM older than 21, and the mod compiles to release
+// 25, so Gradle itself has to run on JDK 25+. Checked here rather than in build.gradle
+// because settings is evaluated before the plugins block resolves Loom, and Gradle's own
+// failure ("This build uses a Java 17 JVM") never says *where* that JVM came from — while
+// org.gradle.java.home in ~/.gradle/gradle.properties silently outranks JAVA_HOME.
+// (This has to sit below pluginManagement: Gradle requires that block to come first.)
+if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_25)) {
+    throw new GradleException("""
+        SpawnHunt needs Gradle running on JDK 25 or newer.
+        It is running on ${JavaVersion.current()} (${System.getProperty('java.home')}).
+
+        Gradle chooses its JVM in this order — the first one set wins:
+          1. -Dorg.gradle.java.home=<path> on the command line
+          2. org.gradle.java.home in ~/.gradle/gradle.properties   <-- outranks JAVA_HOME
+          3. JAVA_HOME, then the java on PATH
+
+        A per-user gradle.properties is the usual culprit. List installed JDKs with
+        `/usr/libexec/java_home -V` (macOS), then either fix that file or run:
+
+          ./gradlew build -Dorg.gradle.java.home=/path/to/jdk-25-or-newer
+    """.stripIndent())
+}
+
 rootProject.name = 'spawnhunt'

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,7 +22,7 @@
   ],
   "depends": {
     "fabricloader": ">=0.19.0",
-    "fabric-api": "*",
+    "fabric-api": ">=${fabric_api_minimum}",
     "minecraft": "~26.2",
     "java": ">=25"
   }


### PR DESCRIPTION
Both of these bit during a routine build-and-deploy of `dev` to the 26.2 test instance. Neither changes mod behaviour — they turn two confusing failures into clear ones.

## The build JVM

Gradle resolves its JVM from `org.gradle.java.home` in `~/.gradle/gradle.properties` **ahead of** `JAVA_HOME`. A per-user pin to an old JDK therefore wins silently, and setting `JAVA_HOME` looks like it does nothing. Loom 1.17 then refuses to resolve with an error that names the version but not its source:

> Could not resolve net.fabricmc:fabric-loom:1.17.19 — Dependency requires at least JVM runtime version 21. This build uses a Java 17 JVM.

`settings.gradle` now checks for JDK 25+ before that happens and explains it. Verified against a real JDK 17:

```
SpawnHunt needs Gradle running on JDK 25 or newer.
It is running on 17 (/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home).

Gradle chooses its JVM in this order — the first one set wins:
  1. -Dorg.gradle.java.home=<path> on the command line
  2. org.gradle.java.home in ~/.gradle/gradle.properties   <-- outranks JAVA_HOME
  3. JAVA_HOME, then the java on PATH
```

Two notes on the approach:

- **Why not a toolchain.** The failure is in *plugin resolution*, before any toolchain applies — and pinning a toolchain to 25 would break a machine that has only a newer JDK. Compilation keeps `options.release = 25`, so 25-or-newer all work and no JDK 25 install is needed.
- **Why it sits below `pluginManagement`.** Gradle requires that block to be the first statement in a settings file. Still early enough, since `build.gradle`'s `plugins` block resolves after settings finishes.

The repo can't fix this by itself — `~/.gradle` outranks project `gradle.properties` — so a good error message is the best available outcome.

## The Fabric API floor

`fabric.mod.json` declared `"fabric-api": "*"` while the build compiles against `fabric_version`. Running against an older API than we build against was therefore a `NoSuchMethodError` mid-game rather than a load-time dependency error.

The floor is now templated from `gradle.properties` through `processResources`, with the build suffix stripped (`0.157.0+26.2` → `0.157.0`), so it can't drift from what we compile against. Confirmed in the built jar:

```json
"depends": {
  "fabricloader": ">=0.19.0",
  "fabric-api": ">=0.157.0",
  "minecraft": "~26.2",
  "java": ">=25"
}
```

**Worth a second opinion:** this floor is strict — 0.156.0 very likely ran fine. The reasoning is that we should declare only what we build and test against, but happy to loosen it. `fabricloader` and `minecraft` were left alone; those read as deliberate ranges rather than drifted copies.

## Docs

The macOS testing path pointed at `SpawnHunt 26.2`, which doesn't exist (actual: `Family 26.2`). Also corrected "must use JDK 25" → "JDK 25 or newer", dropped the hardcoded Windows JDK path from the build command, and documented the `~/.gradle` precedence trap. The Windows instance path is unverified and left as-is.

## Testing

- `./gradlew clean build` green on JDK 26; jar deployed to the 26.2 instance.
- Guard confirmed firing on JDK 17 and passing on JDK 26.
- Expanded `depends` block inspected inside the built jar.
- In-game launch not yet done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)