### PR TITLE
Stop the SpawnHunt button overlapping the Options/Quit row

### DIFF
--- a/src/main/java/com/spawnhunt/mixin/TitleScreenMixin.java
+++ b/src/main/java/com/spawnhunt/mixin/TitleScreenMixin.java
@@ -5,7 +5,10 @@ import com.spawnhunt.screen.SpawnHuntScreen;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.TitleScreen;
+import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.PlainTextButton;
+import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.network.chat.Component;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -14,6 +17,15 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(TitleScreen.class)
 public abstract class TitleScreenMixin extends Screen {
+
+    private static final int BUTTON_WIDTH = 200;
+    private static final int BUTTON_HEIGHT = 20;
+    /** Vanilla's gap between menu rows: rows step by 24 and are 20 tall. */
+    private static final int ROW_GAP = 4;
+    /** LogoRenderer draws at y=30 with a height of 44. */
+    private static final int LOGO_BOTTOM = 74;
+    /** The copyright line is a 10px band pinned to the bottom; stay clear of it. */
+    private static final int COPYRIGHT_CLEARANCE = 12;
 
     protected TitleScreenMixin(Component title) {
         super(title);
@@ -33,8 +45,53 @@ public abstract class TitleScreenMixin extends Screen {
                 Button.builder(Component.literal("SpawnHunt"), button -> {
                     Minecraft.getInstance().gui.setScreen(new SpawnHuntScreen());
                 })
-                .bounds(this.width / 2 - 100, this.height / 4 + 156, 200, 20)
+                .bounds(this.width / 2 - BUTTON_WIDTH / 2, makeRoomForSpawnHuntRow(), BUTTON_WIDTH, BUTTON_HEIGHT)
                 .build()
         );
+    }
+
+    /**
+     * Returns the y for a SpawnHunt row below vanilla's menu stack, sliding the stack up
+     * first if the row wouldn't otherwise fit.
+     *
+     * The position is derived from the widgets vanilla just laid out rather than a fixed
+     * offset — the menu has been reshuffled more than once (26.2 moved the Options/Quit row
+     * onto the offset this mixin used to hardcode), and reading the real layout survives the
+     * next reshuffle too.
+     *
+     * At the largest GUI scales the scaled screen bottoms out around 240px tall, and
+     * vanilla's own stack fills that to within a few pixels of the copyright line — there is
+     * no room for a fourth row. But the stack starts at height/4 + 48 while the logo ends at
+     * 74, so on those short screens the slack is above the menu, not below it. Shifting the
+     * stack up by just what's missing keeps vanilla's spacing intact and stays clear of the
+     * logo. On a normally-sized window nothing needs to move and nothing does.
+     */
+    private int makeRoomForSpawnHuntRow() {
+        int top = Integer.MAX_VALUE;
+        int bottom = Integer.MIN_VALUE;
+        for (GuiEventListener child : this.children()) {
+            // The copyright line is pinned to the bottom of the screen rather than being part
+            // of the menu stack, so it neither anchors the new row nor gets shifted.
+            if (child instanceof AbstractWidget widget && !(child instanceof PlainTextButton)) {
+                top = Math.min(top, widget.getY());
+                bottom = Math.max(bottom, widget.getY() + widget.getHeight());
+            }
+        }
+        if (bottom == Integer.MIN_VALUE) {
+            return this.height / 4 + 168;
+        }
+
+        int missing = (bottom + ROW_GAP + BUTTON_HEIGHT) - (this.height - COPYRIGHT_CLEARANCE);
+        int headroom = top - LOGO_BOTTOM - ROW_GAP;
+        int shift = Math.max(0, Math.min(missing, headroom));
+        if (shift > 0) {
+            for (GuiEventListener child : this.children()) {
+                if (child instanceof AbstractWidget widget && !(child instanceof PlainTextButton)) {
+                    widget.setY(widget.getY() - shift);
+                }
+            }
+            bottom -= shift;
+        }
+        return bottom + ROW_GAP;
     }
 }


### PR DESCRIPTION
## Problem

The SpawnHunt button was pinned at `height / 4 + 156`. The 26.2 title screen lays its rows out from `height / 4 + 48`, which puts the Options/Quit pair at `height / 4 + 144` — spanning y 144→164, straight through that hardcoded offset.

## Fix

Two parts, both in `TitleScreenMixin`:

1. **Derive the position from the layout, not a constant.** `makeRoomForSpawnHuntRow()` measures the widgets vanilla just laid out and places the row one 4px gap below the lowest one. The copyright line is excluded — it's a `PlainTextButton` pinned to the bottom of the screen, not part of the menu stack. This survives the next menu reshuffle.

2. **Slide the stack up when there's no room below it.** At the largest GUI scales the scaled screen bottoms out around 240px tall, and vanilla's own stack reaches to within a few pixels of the copyright line — a fourth row genuinely doesn't fit. On those screens the slack is *above* the menu (stack starts at `height/4 + 48`, logo ends at 74), so the stack shifts up by exactly the shortfall, capped by that headroom.

Vanilla's 4px row spacing is preserved either way, and on a normally-sized window the shift computes to 0 and no vanilla widget is touched.

## Numbers

| scaled height | stack | shift | SpawnHunt row | copyright top |
|---|---|---|---|---|
| 240 (minimum) | 108→224 | 20 | 208→228 | 230 |
| 360 (typical) | 138→254 | 0 | 258→278 | 350 |

## Testing

Built and run against the 26.2 instance. Confirmed at the default window size — which lands at roughly the 240px minimum and was the case that reproduced the overlap — and at a resized larger window, where the layout is unchanged from vanilla.