### PR TITLE
fix dedicated server crash and title screen escape navigation

### DIFF
--- a/src/main/java/com/spawnhunt/data/ItemPool.java
+++ b/src/main/java/com/spawnhunt/data/ItemPool.java
@@ -1,6 +1,6 @@
 package com.spawnhunt.data;
 
-import com.spawnhunt.SpawnHuntMod;
+import com.spawnhunt.SpawnHuntCommon;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.item.Item;
@@ -129,15 +129,15 @@ public class ItemPool {
                     // Defensive: if the component-binding API changes in a future MC patch,
                     // skip the offending item rather than crash the title screen.
                     failed++;
-                    SpawnHuntMod.LOGGER.warn("SpawnHunt: failed to pre-bind components for {}: {}", id, t.toString());
+                    SpawnHuntCommon.LOGGER.warn("SpawnHunt: failed to pre-bind components for {}: {}", id, t.toString());
                 }
             }
         }
         if (bound > 0) {
-            SpawnHuntMod.LOGGER.info("SpawnHunt: pre-bound model components for {} items (pre-world rendering)", bound);
+            SpawnHuntCommon.LOGGER.info("SpawnHunt: pre-bound model components for {} items (pre-world rendering)", bound);
         }
         if (failed > 0) {
-            SpawnHuntMod.LOGGER.warn("SpawnHunt: {} items failed component pre-binding", failed);
+            SpawnHuntCommon.LOGGER.warn("SpawnHunt: {} items failed component pre-binding", failed);
         }
         componentsBound = true;
     }
@@ -169,8 +169,8 @@ public class ItemPool {
     public static void logPool() {
         List<Item> p = getPool();
         for (Item item : p) {
-            SpawnHuntMod.LOGGER.debug("  pool: {}", BuiltInRegistries.ITEM.getKey(item));
+            SpawnHuntCommon.LOGGER.debug("  pool: {}", BuiltInRegistries.ITEM.getKey(item));
         }
-        SpawnHuntMod.LOGGER.info("Item pool initialized — {} survival-obtainable items", p.size());
+        SpawnHuntCommon.LOGGER.info("Item pool initialized — {} survival-obtainable items", p.size());
     }
 }

--- a/src/main/java/com/spawnhunt/screen/SpawnHuntScreen.java
+++ b/src/main/java/com/spawnhunt/screen/SpawnHuntScreen.java
@@ -346,6 +346,11 @@ public class SpawnHuntScreen extends Screen {
     }
 
     @Override
+    public void onClose() {
+        this.minecraft.gui.setScreen(new TitleScreen());
+    }
+
+    @Override
     public boolean mouseClicked(MouseButtonEvent event, boolean selected) {
         if (event.button() == 0 && event.x() >= historyLinkX && event.x() <= historyLinkX + historyLinkW
                 && event.y() >= historyLinkY && event.y() <= historyLinkY + historyLinkH) {


### PR DESCRIPTION
- **Added `onClose()` override in `SpawnHuntScreen`:**
  - *Root Cause:* `SpawnHuntScreen` relied on the default `Screen.onClose()` implementation, which calls `Minecraft.getInstance().gui.setScreen(null)`. Because `SpawnHuntScreen` is accessed prior to loading a world from the main menu, setting the current screen to `null` left the client on an unnavigable panorama with no buttons or UI widgets, soft-locking the main menu when a user pressed Escape.
  - *Fix:* Overrode `onClose()` to redirect to `new TitleScreen()`, making Escape key handling behave consistently with the on-screen "Cancel" button and `ItemChooserScreen.onClose()`.

- **Switched `ItemPool` logger reference to `SpawnHuntCommon`:**
  - *Root Cause:* `ItemPool` is part of the common data model and is accessed on dedicated servers during command execution (`/spawnhunt start random`, `/spawnhunt restart`) and server tick broadcasts (`ServerHuntManager`). It imported and called `SpawnHuntMod.LOGGER`. Because `SpawnHuntMod` is the `ClientModInitializer` containing direct references to client-only classes (`DeathScreen`, client Fabric API lifecycle events, `HudElementRegistry`), class-loading `SpawnHuntMod` in a headless dedicated server environment caused a `NoClassDefFoundError` crash.
  - *Fix:* Updated `ItemPool` to import and reference `SpawnHuntCommon.LOGGER`, keeping `ItemPool` side-clean and safe to load on dedicated servers.