### PR TITLE
Port to Minecraft 26.3, and fix the History panel

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -48,7 +48,7 @@ body:
     id: minecraft-version
     attributes:
       label: Minecraft version
-      placeholder: "e.g. 1.21.11"
+      placeholder: "e.g. 26.3"
     validations:
       required: true
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,18 +1,23 @@
 # SpawnHunt
 
-A Fabric mod for Minecraft Java Edition 26.2.
+A Fabric mod for Minecraft Java Edition 26.3.
 Speedrun-style scavenger hunt: find and collect a random survival-obtainable block as fast as possible.
 Supports both singleplayer (client-side) and multiplayer (server-side commands + HUD sync).
 
 ## Testing Environment
 
 - **Minecraft instance (macOS):** `/Applications/MultiMC.app/Data/instances/Family 26.2/.minecraft`
-- **Minecraft instance (Windows):** `C:\MultiMC\instances\SpawnHunt 26.2\.minecraft`
+  — still a 26.2 instance; a 26.3 one has to be created before the port can be playtested in-game.
+- **Minecraft instance (Windows):** `C:\MultiMC\instances\SpawnHunt 26.2\.minecraft` — same.
 - The instance's Fabric API must be **at least** `fabric_version` from `gradle.properties`;
   `fabric.mod.json` declares that floor, so Fabric refuses to load with a clear message
   instead of dying on a `NoSuchMethodError` mid-game.
 - Built `.jar` goes into the `mods/` folder of that instance
-- Requires Fabric Loader + Fabric API for MC 26.2
+- Requires Fabric Loader + Fabric API for MC 26.3
+- **No MultiMC instance needed for a smoke test:** `./gradlew runServer` boots a headless
+  dev server with the mod loaded (accept the EULA once in `run/eula.txt`). That exercises
+  the common entrypoint, `/spawnhunt`, the item pool against the real registry, and
+  `GameModeLockMixin` — everything except the client screens and HUD.
 
 ## Project Structure
 
@@ -53,8 +58,8 @@ com.spawnhunt
 - **Java:** JDK 25 **or newer** — Gradle itself must run on it. Compilation pins `options.release = 25`,
   so a newer JDK (26 etc.) is fine and no JDK 25 install is required. `settings.gradle` fails fast with
   the fix if the JVM is too old.
-- **Dependencies:** fabric-loader 0.19.3, fabric-api 0.157.0+26.2
-- **Mappings:** None (MC 26.2 is unobfuscated — uses Mojang official names directly)
+- **Dependencies:** fabric-loader 0.19.3, fabric-api 0.157.1+26.3
+- **Mappings:** None (MC 26.3 is unobfuscated — uses Mojang official names directly)
 - **Language:** Java
 
 ## Build Commands
@@ -144,6 +149,31 @@ has no effect against it. Either fix that file or override per-invocation:
 - [x] P4 Verify mixin targets and access widener still resolve against 26.2
 - [x] P5 Audit the 31 new items for survival obtainability (no exclusions needed)
 
+### Phase 26.3 — Port to Minecraft 26.3 "Dappled Forest"
+- [x] Q1 Toolchain bump (MC 26.3-snapshot-8, fabric-api 0.157.1+26.3; loader, Loom and Gradle unchanged)
+- [x] Q2 `fabric.mod.json` predicate `~26.3-` — the trailing hyphen is what makes it match
+      snapshot builds as well as the eventual 26.3 release (Fabric API declares its own the same way)
+- [x] Q3 Verify mixin targets and the access widener still resolve against 26.3 (all unchanged)
+- [x] Q4 Audit the 121 new items for survival obtainability (no exclusions needed — see below)
+- [x] Q5 Headless `runServer` smoke test on 26.3-snapshot-8
+
+**The 26.3 item audit.** 121 items added, none removed, so the pool goes 1409 → 1530.
+Every one is survival-obtainable, so `ItemPool.EXCLUDED` is untouched:
+
+- Poplar wood set, wool/concrete stairs and slabs, cushions, straw bed, boats — craftable.
+- Poplar logs/leaves/sapling, red shrub, shelf mushroom — block drops.
+- 16 new map items — this is the only interesting call. Explorer maps used to be `filled_map`
+  with components (hence the `filled_map` exclusion); in 26.3 they are their own registry
+  entries, so they enter the pool on their own IDs. All are reachable — abandoned-camp chest
+  loot, shipwreck/ruin loot, or cartographer trades — but some are *slow*: the village and
+  ocean/swamp explorer maps are trade-only, and `woodland_explorer_map` needs a Master-level
+  cartographer. Kept in, because the pool's rule is "survival-obtainable", and it already
+  contains comparably long targets (`nether_star`, `dragon_egg`, `elytra`).
+
+The audit is reproducible without launching the game: the item registry is exactly the set of
+`assets/minecraft/items/*.json` entries in the client jar, and `data/minecraft/{recipe,loot_table,
+villager_trade}` says how each one is obtained. Diff two client jars to get the delta.
+
 ### Phase H — Hardening (from the July 2026 code review)
 - [x] H1 Server state lifecycle (reset `ServerHuntState` + tick counter on `SERVER_STOPPED`)
 - [x] H2 Game-mode gate on multiplayer wins (survival/adventure only)
@@ -182,7 +212,7 @@ has no effect against it. Either fix that file or override per-invocation:
   anything not reset leaks into the next world.
 - **Vanilla client support** — players without the mod see action bar messages during active hunts and chat messages for start/stop/win events.
 - **Multiplayer commands** require OP level 2 (GAMEMASTERS); `/spawnhunt status` is available to all players.
-- **Pre-world item rendering** — MC 26.2 binds item components (including `ITEM_MODEL`) during world load, but the selection screen runs pre-world. `ItemPool.ensureComponentsBound()` binds a minimal `DataComponentMap` with `ITEM_MODEL` set to the item's registry ID so `ItemStack` creation and rendering works on the title screen. Vanilla overwrites with full data-driven components during world load.
+- **Pre-world item rendering** — MC 26.3 binds item components (including `ITEM_MODEL`) during world load, but the selection screen runs pre-world. `ItemPool.ensureComponentsBound()` binds a minimal `DataComponentMap` with `ITEM_MODEL` set to the item's registry ID so `ItemStack` creation and rendering works on the title screen. Vanilla overwrites with full data-driven components during world load.
 - **Display names** use `Component.translatable(item.getDescriptionId())` instead of `ItemStack.getHoverName()` to avoid creating ItemStacks for name resolution (safe pre-world).
 
 ## Key Risks
@@ -212,9 +242,28 @@ The release flow:
 
 Only a merged `release/*` branch cuts a release; a `dev`/`hotfix` merge to `main` builds nothing.
 
-## API Notes (MC 26.2)
+## API Notes (MC 26.3)
 
-Changes introduced by the 26.1 → 26.2 port:
+The 26.2 → 26.3 port needed **no source changes at all** — it is a version bump plus metadata.
+Worth recording, because "nothing moved" is itself the finding:
+
+- Every mixin and access-widener target is byte-identical in shape: `TitleScreen.init()`,
+  `CreateWorldScreen.init()`/`onCreate()`/`getUiState()`, and
+  `ServerPlayer.setGameMode(GameType)` still returning `boolean`.
+- The fragile pre-world path survived intact — `Item.builtInRegistryHolder()` (still deprecated,
+  still present), `Holder.Reference.bindComponents`/`areComponentsBound`, and
+  `DataComponents.ITEM_MODEL` typed as `DataComponentType<Identifier>`.
+- `WorldCreationUiState` kept `setName`/`getName`/`setGameMode`/`setDifficulty`/`setAllowCommands`
+  and the `SelectedGameMode.SURVIVAL`/`HARDCORE` constants.
+- Loom 1.17.19 and Gradle 9.5.1 handle 26.3 snapshots as-is; no toolchain bump was needed.
+
+Carried over from 26.2 (still current):
+
+- MC 26.3 is unobfuscated, same as 26.2 — no mappings.
+- `Gui` owns the screen stack and the HUD: `Minecraft.gui.setScreen(s)`, `Minecraft.gui.screen()`,
+  `Minecraft.gui.hud`.
+
+Changes introduced by the earlier 26.1 → 26.2 port:
 
 - `Gui` now owns the screen stack and the HUD. `Minecraft.setScreen(s)` → `Minecraft.gui.setScreen(s)`,
   and the `Minecraft.screen` field → `Minecraft.gui.screen()`. `Minecraft.gui.hud` is the new
@@ -273,4 +322,4 @@ Carried over from 26.1 (still current):
 ## Conventions
 
 - Keep mixin surface area minimal to reduce breakage on MC updates.
-- Target MC 26.2, use only stable Fabric API modules.
+- Target MC 26.3, use only stable Fabric API modules.

--- a/MODRINTH.md
+++ b/MODRINTH.md
@@ -34,23 +34,23 @@
 
 ## Features
 
-- **1,400+ target items** — every survival-obtainable item in the game, randomly selected each run
+- **1,500+ target items** — every survival-obtainable item in the game, randomly selected each run, including everything new in 26.3
 - **Singleplayer** — built-in timer with pause awareness, saved run history and best times, Hardcore mode
 - **Multiplayer** — server commands, automatic inventory scanning, works with vanilla clients
 - **Zero setup** — one click to start a singleplayer hunt, one command to start a multiplayer one. No config files.
 
 ## Requirements
 
-- Minecraft Java Edition **26.2**
+- Minecraft Java Edition **26.3**
 - [Fabric Loader](https://fabricmc.net/) **0.19.0+**
-- [Fabric API](https://modrinth.com/mod/fabric-api) **0.157.0+**
+- [Fabric API](https://modrinth.com/mod/fabric-api) **0.157.1+**
 - Java **25+**
 
 ## Installation
 
 ### Client (singleplayer + multiplayer HUD)
 
-1. Install Fabric Loader and Fabric API for Minecraft 26.2
+1. Install Fabric Loader and Fabric API for Minecraft 26.3
 2. Drop the `spawnhunt` jar into your `mods` folder
 3. Launch the game — the **SpawnHunt** button appears on the title screen
 

--- a/README.md
+++ b/README.md
@@ -22,21 +22,21 @@
 
 ## Features
 
-- **400+ target items** — every survival-obtainable item in the game
+- **1,500+ target items** — every survival-obtainable item in the game, including the 26.3 poplar wood set, cushions, wool/concrete stairs and slabs, and the new explorer maps
 - **Singleplayer** — built-in timer with pause awareness, run history, hardcore mode
 - **Multiplayer** — server commands, automatic inventory scanning, works with vanilla clients
 - **Zero setup** — singleplayer worlds created with a single click; multiplayer via one command
 
 ## Requirements
 
-- Minecraft Java Edition 1.21.11
-- [Fabric Loader](https://fabricmc.net/) 0.18.4+
-- [Fabric API](https://modrinth.com/mod/fabric-api) 0.141.3+
+- Minecraft Java Edition 26.3
+- [Fabric Loader](https://fabricmc.net/) 0.19.0+
+- [Fabric API](https://modrinth.com/mod/fabric-api) 0.157.1+
 
 ## Installation
 
 ### Client (singleplayer + enhanced multiplayer HUD)
-1. Install Fabric Loader and Fabric API for Minecraft 1.21.11
+1. Install Fabric Loader and Fabric API for Minecraft 26.3
 2. Drop the `spawnhunt` jar into your `mods` folder
 3. Launch the game — the **SpawnHunt** button appears on the title screen
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ repositories {
 dependencies {
     // To change the versions see the gradle.properties file
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
-    // No mappings needed — MC 26.2 is unobfuscated
+    // No mappings needed — MC 26.3 is unobfuscated
     implementation "net.fabricmc:fabric-loader:${project.loader_version}"
     implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 }
@@ -27,7 +27,7 @@ dependencies {
 processResources {
     // The Fabric API version we compile against is also the minimum we claim to run on,
     // so fabric.mod.json takes its floor from gradle.properties rather than a hand-kept
-    // copy that drifts. Strip the build suffix (0.157.0+26.2 -> 0.157.0): the predicate
+    // copy that drifts. Strip the build suffix (0.157.1+26.3 -> 0.157.1): the predicate
     // wants a bare version, and semver ignores build metadata when comparing anyway.
     def fabricApiMinimum = project.fabric_version.split('\\+')[0]
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ systemProp.org.gradle.internal.http.socketTimeout=120000
 
 # Fabric Properties
 # Check these at https://fabricmc.net/develop/
-minecraft_version=26.2
+minecraft_version=26.3-snapshot-8
 loader_version=0.19.3
 
 # Mod Properties
@@ -17,4 +17,4 @@ maven_group=com.spawnhunt
 archives_base_name=spawnhunt
 
 # Dependencies
-fabric_version=0.157.0+26.2
+fabric_version=0.157.1+26.3

--- a/src/main/java/com/spawnhunt/data/ItemPool.java
+++ b/src/main/java/com/spawnhunt/data/ItemPool.java
@@ -52,7 +52,11 @@ public class ItemPool {
             "petrified_oak_slab",
             "player_head",
 
-            // Variant-dependent (identity determined by components, not item ID)
+            // Variant-dependent (identity determined by components, not item ID).
+            // Note that as of 26.3 the explorer/village/structure maps are *not* in this
+            // bucket: they became real registry items (ocean_explorer_map, buried_treasure_map,
+            // abandoned_camp_map, …) rather than filled_map + components, so they carry their
+            // own identity and stay in the pool. Only the generic filled_map is excluded.
             "potion",
             "splash_potion",
             "lingering_potion",
@@ -107,7 +111,7 @@ public class ItemPool {
      * created pre-world for the selection screen. Vanilla overwrites with full
      * data-driven components during world load.
      *
-     * <p>{@code builtInRegistryHolder()} is deprecated as of MC 26.2 but still
+     * <p>{@code builtInRegistryHolder()} is deprecated as of MC 26.2 (still true in 26.3) but still
      * present and functional; there is no non-deprecated way to bind components
      * pre-world. This is the most likely call site to break on the next MC update.
      */

--- a/src/main/java/com/spawnhunt/data/ResultStore.java
+++ b/src/main/java/com/spawnhunt/data/ResultStore.java
@@ -82,6 +82,16 @@ public class ResultStore {
         save();
     }
 
+    /**
+     * Whether this item has any recorded runs. Deliberately avoids the copy-and-sort
+     * that {@link #getLastRuns} does — callers use this to decide whether to *offer*
+     * the history view, which is a question the render loop asks every frame.
+     */
+    public static boolean hasRuns(Identifier blockId) {
+        ensureLoaded();
+        return !cache.getOrDefault(blockId.toString(), Collections.emptyList()).isEmpty();
+    }
+
     public static List<RunResult> getLastRuns(Identifier blockId, int count) {
         ensureLoaded();
         List<RunResult> runs = cache.getOrDefault(blockId.toString(), Collections.emptyList());

--- a/src/main/java/com/spawnhunt/screen/SpawnHuntScreen.java
+++ b/src/main/java/com/spawnhunt/screen/SpawnHuntScreen.java
@@ -4,6 +4,7 @@ import com.spawnhunt.data.HuntState;
 import com.spawnhunt.data.ItemPool;
 import com.spawnhunt.data.ResultStore;
 import net.minecraft.client.Minecraft;
+import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.Screen;
@@ -371,9 +372,14 @@ public class SpawnHuntScreen extends Screen {
 
     @Override
     public boolean mouseClicked(MouseButtonEvent event, boolean selected) {
+        // MOUSE_BUTTON_LEFT is 1, not 0 — MC's mouse buttons are 1-based (LEFT 1, MIDDLE 2,
+        // RIGHT 3), unlike the GLFW codes the old Click API exposed. Hardcoding 0 here is what
+        // silently killed this link in the 26.1 port; vanilla's own isValidClickButton
+        // compares against MOUSE_BUTTON_LEFT, so use the constant rather than a literal.
+        //
         // historyLinkActive is the real gate — the bounds alone are not enough, since a
         // zero-width "cleared" box still matches a click landing exactly on its corner.
-        if (historyLinkActive && event.button() == 0
+        if (historyLinkActive && event.button() == InputConstants.MOUSE_BUTTON_LEFT
                 && event.x() >= historyLinkX && event.x() <= historyLinkX + historyLinkW
                 && event.y() >= historyLinkY && event.y() <= historyLinkY + historyLinkH) {
             showHistory = !showHistory;

--- a/src/main/java/com/spawnhunt/screen/SpawnHuntScreen.java
+++ b/src/main/java/com/spawnhunt/screen/SpawnHuntScreen.java
@@ -73,6 +73,11 @@ public class SpawnHuntScreen extends Screen {
 
     // Clickable "History" / "Back" link bounds (set during render)
     private int historyLinkX, historyLinkY, historyLinkW, historyLinkH;
+    /** False when the link is dimmed (no runs to show) or hidden (mid-roll) — clicks are ignored. */
+    private boolean historyLinkActive;
+    // hasRuns() hits the result cache, but render() asks every frame, so memoise per item.
+    private Item cachedHistoryItem;
+    private boolean cachedHasHistory;
 
     public SpawnHuntScreen() {
         super(Component.literal("SpawnHunt"));
@@ -295,23 +300,42 @@ public class SpawnHuntScreen extends Screen {
 
         // History toggle link (hidden during rolling)
         if (!isRolling) {
+            // Most items have never been run, and a link onto two empty panels is a dead end.
+            // So it is dimmed and inert unless there is something behind it — except while the
+            // history is open, where the link is the only way back out.
+            boolean active = showHistory || hasHistory();
+
             Component linkText = Component.literal(showHistory ? "< Back" : "History >");
             int linkW = this.getFont().width(linkText);
             int linkX = centerX - linkW / 2;
-            boolean hovering = mouseX >= linkX && mouseX <= linkX + linkW
+            boolean hovering = active && mouseX >= linkX && mouseX <= linkX + linkW
                     && mouseY >= curY && mouseY <= curY + TEXT_H;
-            int linkColor = hovering ? 0xFF88CCFF : 0xFF6699CC;
+
+            int linkColor;
+            if (!active) {
+                linkColor = 0xFF667788;      // muted — keeps the link's hue, reads as unavailable
+            } else {
+                linkColor = hovering ? 0xFF88CCFF : 0xFF6699CC;
+            }
             context.text(this.getFont(), linkText, linkX, curY, linkColor, true);
 
             historyLinkX = linkX;
             historyLinkY = curY;
             historyLinkW = linkW;
             historyLinkH = TEXT_H;
+            historyLinkActive = active;
         } else {
-            // Clear link bounds so clicks don't register during rolling
-            historyLinkW = 0;
-            historyLinkH = 0;
+            historyLinkActive = false;
         }
+    }
+
+    /** Whether the current target has recorded runs, memoised against the item it was resolved for. */
+    private boolean hasHistory() {
+        if (targetItem != cachedHistoryItem) {
+            cachedHistoryItem = targetItem;
+            cachedHasHistory = ResultStore.hasRuns(BuiltInRegistries.ITEM.getKey(targetItem));
+        }
+        return cachedHasHistory;
     }
 
     private void renderHistoryArea(GuiGraphicsExtractor context, int centerX, int areaY) {
@@ -347,7 +371,10 @@ public class SpawnHuntScreen extends Screen {
 
     @Override
     public boolean mouseClicked(MouseButtonEvent event, boolean selected) {
-        if (event.button() == 0 && event.x() >= historyLinkX && event.x() <= historyLinkX + historyLinkW
+        // historyLinkActive is the real gate — the bounds alone are not enough, since a
+        // zero-width "cleared" box still matches a click landing exactly on its corner.
+        if (historyLinkActive && event.button() == 0
+                && event.x() >= historyLinkX && event.x() <= historyLinkX + historyLinkW
                 && event.y() >= historyLinkY && event.y() <= historyLinkY + historyLinkH) {
             showHistory = !showHistory;
             return true;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,7 +23,7 @@
   "depends": {
     "fabricloader": ">=0.19.0",
     "fabric-api": ">=${fabric_api_minimum}",
-    "minecraft": "~26.2",
+    "minecraft": "~26.3-",
     "java": ">=25"
   }
 }


### PR DESCRIPTION
Ports the mod to Minecraft 26.3, and fixes the History panel — which turned out to have been broken since v3.0.0.

Three commits: the port, the History link's disabled state, and the click fix.

## Port to 26.3

`26.3-snapshot-8` + `fabric-api 0.157.1+26.3`. Loader, Loom and Gradle are unchanged.

**No source changes were needed for the port itself.** Every mixin target, the access widener, and the fragile pre-world component binding path all survived the update:

| Target | 26.3 |
|---|---|
| `TitleScreen.init()` | unchanged |
| `CreateWorldScreen.init()` / `onCreate()` / `getUiState()` | unchanged |
| `ServerPlayer.setGameMode(GameType)` | unchanged, still returns `boolean` |
| `Item.builtInRegistryHolder()`, `bindComponents`, `areComponentsBound` | unchanged (still deprecated) |
| `DataComponents.ITEM_MODEL` | unchanged, still `DataComponentType<Identifier>` |

One thing that is easy to get wrong: the `fabric.mod.json` predicate is `~26.3-`, not `~26.3`. The trailing hyphen is what makes it match snapshot builds as well as the eventual release — without it Fabric refuses to load on `26.3-snapshot-8`, because a snapshot sorts *below* `26.3` as a prerelease. Fabric API declares its own dependency the same way.

## Item pool

26.3 adds **121 items and removes none**, so the pool goes **1409 → 1530**. All 121 are survival-obtainable, so `ItemPool.EXCLUDED` is untouched.

- Poplar wood set, wool/concrete stairs and slabs, cushions, straw bed, boats — craftable
- Poplar logs/leaves/sapling, red shrub, shelf mushroom — block drops
- **16 new map items** — the only real judgement call. Explorer maps used to be `filled_map` plus components, which is exactly why `filled_map` is excluded; in 26.3 they became real registry entries and so carry their own identity. Some are slow to reach (the village and ocean/swamp maps are cartographer-trade-only, and `woodland_explorer_map` needs a Master-level cartographer), but the pool's rule is "survival-obtainable" and it already contains `nether_star`, `dragon_egg` and `elytra`.

The audit is reproducible without launching the game, and `CLAUDE.md` records how: the item registry is exactly the set of `assets/minecraft/items/*.json` entries in the client jar, and `data/minecraft/{recipe,loot_table,villager_trade}` says how each one is obtained. Diff two client jars to get the delta.

## History panel: two separate problems

### 1. The link was offered on every item

With ~1530 items in the pool and history only written for singleplayer wins, almost every click opened two panels reading "No runs yet" — a dead end dressed as a link. It is now muted and inert unless the target has runs.

- **Hover is suppressed too.** Dimming alone would still light the link up under the cursor and read as clickable.
- **`< Back` stays active.** The gate is `showHistory || hasHistory()`, not just `hasHistory()` — the link is the only way out of the panel view.
- **Clicks are gated on a flag, not on the bounds.** The old code disabled the link mid-roll by zeroing its width and height, but a zero-size box still matches a click landing exactly on its corner, since `x >= linkX && x <= linkX + 0` holds at that pixel.

`ResultStore.hasRuns()` is new — `getLastRuns` copies and sorts the list, which is fine on a click but not in `render()`, which asks every frame. It is also memoised per item in the screen, so the common case is a reference comparison.

### 2. The link never responded to clicks at all — a pre-existing bug

Dimming the link is what exposed this: until now it only ever sat on items with no runs, where a dead click and an empty result look identical.

**MC's mouse buttons are 1-based.** `InputConstants.MOUSE_BUTTON_LEFT` is `1`, with MIDDLE `2` and RIGHT `3`, where the old `Click` API exposed raw GLFW codes with left at `0`. The hit test still checked `event.button() == 0`, which no left click ever satisfies, so the panel could never be opened.

This dates to the **26.1 port (`6df26a5`)**, which swapped `Click` for `MouseButtonEvent` without accounting for the renumbering — so the History panel has been dead in **every release since v3.0.0**. It is not a 26.3 regression.

Diagnosed by logging the click against the stored bounds:

```
click btn=1 at (290.66, 197.33) | link active=true box=(258, 191) 45x10
```

Every condition passed except the button. The coordinates were correct all along — both paths use the same GUI-scaled space, since `MouseHandler` builds the event via `getScaledXPos`/`getScaledYPos`.

The fix compares against the constant rather than a literal `1`, since vanilla's own `AbstractWidget.isValidClickButton` does the same and a bare literal is what caused this in the first place.

## Verification

- Compiles against `26.3-snapshot-8`
- Every mixin and access-widener target checked against the 26.3 client jar
- Headless `runServer` boots and the command tree works: new 26.3 items (`poplar_planks`, `woodland_explorer_map`) start hunts with correct display names, while `filled_map` and `bedrock` are still correctly rejected as out-of-pool
- **Client launched on 26.3** — logs `Item pool initialized — 1530 survival-obtainable items` and `pre-bound model components for 1658 items`, with no failures, no mixin errors and no exceptions
- **History panel confirmed working in-game** — a completed run now opens and displays correctly, which it did not do before this branch

## Not included

`CHANGELOG.md` and the `mod_version` bump are deliberately absent — per the release process both happen on the `release/X.Y.Z` branch, not here. Worth noting when that entry is written: the History fix is user-facing and applies to everyone on v3.x/v4.x, not just 26.3 players.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
